### PR TITLE
fix: Fix FK field type to match related model's PK type

### DIFF
--- a/docs/fields.mdx
+++ b/docs/fields.mdx
@@ -397,7 +397,13 @@ late int authorId;
 // With custom column name
 @ForeignKey(Category, onDelete: OnDelete.setNull, dbColumn: 'cat_id')
 late int? categoryId;
+
+// FK to a model with UUID primary key
+@ForeignKey(Organization, onDelete: OnDelete.cascade)
+late String orgId;
 ```
+
+The FK field type is automatically resolved from the related model's primary key type. If the related model uses `@UuidPrimaryKey()`, the FK field should be `String`. If it uses `@AutoField()` or `@BigAutoField()`, use `int`.
 
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
@@ -413,7 +419,7 @@ late int? categoryId;
 | `OnDelete.restrict` | Prevent deletion if references exist |
 | `OnDelete.noAction` | Database default behavior |
 
-**Database Type:** `INTEGER REFERENCES table(id)`
+**Database Type:** Matches the related model's primary key type (e.g. `INTEGER REFERENCES` for int PKs, `UUID REFERENCES` for UUID PKs)
 
 ### OneToOneField
 
@@ -424,9 +430,9 @@ One-to-one relationship.
 late int userId;
 ```
 
-Same options as ForeignKey, but enforces uniqueness.
+Same options as ForeignKey, but enforces uniqueness. The field type is resolved from the related model's primary key, just like ForeignKey.
 
-**Database Type:** `INTEGER UNIQUE REFERENCES table(id)`
+**Database Type:** Matches the related model's primary key type with a UNIQUE constraint
 
 ## Field Type Summary
 
@@ -454,8 +460,8 @@ Same options as ForeignKey, but enforces uniqueness.
 | `@JsonField()` | `dynamic` | `JSONB` | `TEXT` | `JSON` |
 | `@BinaryField()` | `List<int>` | `BYTEA` | `BLOB` | `LONGBLOB` |
 | `@EnumField<T>()` | `T` | `VARCHAR` | `VARCHAR` | `VARCHAR` |
-| `@ForeignKey()` | `int` | `INTEGER REFERENCES` | `INTEGER REFERENCES` | `INT REFERENCES` |
-| `@OneToOneField()` | `int` | `INTEGER UNIQUE REFERENCES` | `INTEGER UNIQUE REFERENCES` | `INT UNIQUE REFERENCES` |
+| `@ForeignKey()` | `int` or `String` | `REFERENCES` (type matches related PK) | `REFERENCES` | `REFERENCES` |
+| `@OneToOneField()` | `int` or `String` | `UNIQUE REFERENCES` (type matches related PK) | `UNIQUE REFERENCES` | `UNIQUE REFERENCES` |
 
 ## Next Steps
 

--- a/packages/example/routes/api/polls/[id]/choices.dart
+++ b/packages/example/routes/api/polls/[id]/choices.dart
@@ -24,6 +24,7 @@ Future<Response> onRequest(RequestContext context, String id) async {
   return switch (context.request.method) {
     HttpMethod.get => _listChoices(pollId),
     HttpMethod.post => _createChoice(context, pollId),
+    HttpMethod.patch => _updateChoice(context, pollId),
     _ => Future.value(
         Response(statusCode: 405, body: 'Method not allowed'),
       ),
@@ -70,6 +71,69 @@ Future<Response> _createChoice(RequestContext context, int pollId) async {
         'poll': pollId,
         'choice_text': choice.choiceText,
         'votes': choice.votes,
+      },
+    );
+  } catch (e) {
+    return Response.json(
+      statusCode: 400,
+      body: {'error': e.toString()},
+    );
+  }
+}
+
+Future<Response> _updateChoice(RequestContext context, int pollId) async {
+  try {
+    final body = await context.request.body();
+    final data = jsonDecode(body) as Map<String, dynamic>;
+
+    if (!data.containsKey('id')) {
+      return Response.json(
+        statusCode: 400,
+        body: {'error': 'id is required'},
+      );
+    }
+
+    final choiceId = data['id'] as int;
+    final choices = await Choices.objects
+        .filter(Choices.$.id.eq(choiceId))
+        .filter(Choices.$.pollId.eq(pollId))
+        .toList();
+
+    if (choices.isEmpty) {
+      return Response.json(
+        statusCode: 404,
+        body: {'error': 'Choice not found'},
+      );
+    }
+
+    final choice = choices.first;
+    final updates = <String, dynamic>{};
+    if (data.containsKey('choice_text')) {
+      updates['choice_text'] = data['choice_text'] as String;
+    }
+    if (data.containsKey('votes')) {
+      updates['votes'] = data['votes'] as int;
+    }
+    if (data['vote'] == true) {
+      updates['votes'] = choice.votes + 1;
+    }
+
+    if (updates.isEmpty) {
+      return Response.json(
+        statusCode: 400,
+        body: {'error': 'No valid fields to update'},
+      );
+    }
+
+    await Choices.objects.filter(Choices.$.id.eq(choiceId)).update(updates);
+    final updated = await Choices.objects.get(choiceId);
+
+    return Response.json(
+      body: {
+        'id': updated.id,
+        'poll': pollId,
+        'choice_text': updated.choiceText,
+        'votes': updated.votes,
       },
     );
   } catch (e) {

--- a/packages/example/routes/api/polls/[id]/choices.dart
+++ b/packages/example/routes/api/polls/[id]/choices.dart
@@ -94,10 +94,8 @@ Future<Response> _updateChoice(RequestContext context, int pollId) async {
     }
 
     final choiceId = data['id'] as int;
-    final choices = await Choices.objects
-        .filter(Choices.$.id.eq(choiceId))
-        .filter(Choices.$.pollId.eq(pollId))
-        .toList();
+    final choices =
+        await Choices.objects.filter(Choices.$.id.eq(choiceId)).filter(Choices.$.pollId.eq(pollId)).toList();
 
     if (choices.isEmpty) {
       return Response.json(

--- a/packages/jao_generator/CHANGELOG.md
+++ b/packages/jao_generator/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [0.2.2] - 2026-02-02
+
+### Fixed
+
+- Foreign key field type now resolves from the related model's primary key type instead of being hardcoded to `int`
+- `@ForeignKey` and `@OneToOneField` to a model with `@UuidPrimaryKey` now correctly generates `String`/`StringFieldRef` instead of `int`/`IntFieldRef`
+
+### Added
+
+- `_resolvePkType` helper for inspecting related model PK annotations at generation time
+- Tests for FK type resolution with `@UuidPrimaryKey` and `@AutoField` targets
+
 ## [0.2.1] - 2026-01-01
 
 ### Added

--- a/packages/jao_generator/lib/src/generator.dart
+++ b/packages/jao_generator/lib/src/generator.dart
@@ -131,10 +131,11 @@ class JaoGenerator extends GeneratorForAnnotation<Model> {
         case 'ManyToManyField':
           final toField = value.getField('to');
           String? relatedModel;
+          DartType? relatedDartType;
           if (toField != null) {
-            final toType = toField.toTypeValue();
-            if (toType != null) {
-              relatedModel = toType.getDisplayString();
+            relatedDartType = toField.toTypeValue();
+            if (relatedDartType != null) {
+              relatedModel = relatedDartType.getDisplayString();
             }
           }
           final toColumn = value.getField('toColumn')?.toStringValue() ?? 'id';
@@ -145,10 +146,11 @@ class JaoGenerator extends GeneratorForAnnotation<Model> {
             'ManyToManyField' => _RelationType.manyToMany,
             _ => _RelationType.foreignKey,
           };
+          final (pkType, pkFieldRef, pkDbType) = _resolvePkType(relatedDartType);
           return _FieldAnnotationInfo(
-            'int',
-            'IntFieldRef',
-            'integer',
+            pkType,
+            pkFieldRef,
+            pkDbType,
             annotation.toSource(),
             relation: relatedModel != null && relatedTable != null
                 ? _RelationInfo(
@@ -170,6 +172,34 @@ class JaoGenerator extends GeneratorForAnnotation<Model> {
       }
     }
     return null;
+  }
+
+  /// Resolves the primary key type of a related model by inspecting its fields.
+  (String, String, String) _resolvePkType(DartType? relatedType) {
+    const defaultPk = ('int', 'IntFieldRef', 'integer');
+
+    if (relatedType == null || relatedType.element is! ClassElement) {
+      return defaultPk;
+    }
+
+    final classElement = relatedType.element as ClassElement;
+    for (final field in classElement.fields) {
+      if (field.isStatic || field.isSynthetic) continue;
+      for (final annotation in field.metadata.annotations) {
+        final value = annotation.computeConstantValue();
+        if (value == null) continue;
+        final typeName = value.type?.getDisplayString();
+        switch (typeName) {
+          case 'AutoField':
+            return ('int', 'IntFieldRef', 'integer');
+          case 'BigAutoField':
+            return ('int', 'IntFieldRef', 'bigInt');
+          case 'UuidPrimaryKey':
+            return ('String', 'StringFieldRef', 'uuid');
+        }
+      }
+    }
+    return defaultPk;
   }
 
   _FieldInfo? _inferFieldType(FieldElement field) {

--- a/packages/jao_generator/pubspec.yaml
+++ b/packages/jao_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: jao_generator
 description: Code generator for jao ORM. Generates typed field accessors and model metadata.
-version: 0.2.1
+version: 0.2.2
 homepage: https://jao.nexlab.studio/
 repository: https://github.com/nexlabstudio/jao
 issue_tracker: https://github.com/nexlabstudio/jao/issues

--- a/packages/jao_generator/test/generator/generator_integration_test.dart
+++ b/packages/jao_generator/test/generator/generator_integration_test.dart
@@ -654,6 +654,78 @@ class Article {
       );
     });
 
+    test('Generator handles @ForeignKey to model with @UuidPrimaryKey', () async {
+      await testBuilder(
+        builder,
+        {
+          'jao|lib/jao.dart': _jaoStub,
+          'pkg|lib/models.dart': '''
+import 'package:jao/jao.dart';
+
+@Model()
+class Organization {
+  @UuidPrimaryKey()
+  late String id;
+  late String name;
+}
+
+@Model()
+class Employee {
+  @AutoField()
+  late int id;
+  @ForeignKey(Organization)
+  late String orgId;
+}
+''',
+        },
+        outputs: {
+          'pkg|lib/models.jao.dart': decodedMatches(
+            allOf([
+              contains("final orgId = const StringFieldRef('org_id')"),
+              contains("RelationMeta("),
+              contains("relatedModel: Organization"),
+            ]),
+          ),
+        },
+      );
+    });
+
+    test('Generator handles @ForeignKey to model with @AutoField', () async {
+      await testBuilder(
+        builder,
+        {
+          'jao|lib/jao.dart': _jaoStub,
+          'pkg|lib/models.dart': '''
+import 'package:jao/jao.dart';
+
+@Model()
+class Author {
+  @AutoField()
+  late int id;
+  late String name;
+}
+
+@Model()
+class Post {
+  @AutoField()
+  late int id;
+  @ForeignKey(Author)
+  late int authorId;
+}
+''',
+        },
+        outputs: {
+          'pkg|lib/models.jao.dart': decodedMatches(
+            allOf([
+              contains("final authorId = const IntFieldRef('author_id')"),
+              contains("RelationMeta("),
+              contains("relatedModel: Author"),
+            ]),
+          ),
+        },
+      );
+    });
+
     test('Generator handles nullable int and double fields', () async {
       await testBuilder(
         builder,
@@ -821,6 +893,10 @@ class TimeField {
 
 class UuidField {
   const UuidField();
+}
+
+class UuidPrimaryKey extends UuidField {
+  const UuidPrimaryKey();
 }
 
 class JsonField {


### PR DESCRIPTION
Foreign key fields were hardcoded to int/IntFieldRef regardless of the related model's primary key type. Now the generator resolves the related model's PK annotation and generates the correct type (e.g. StringFieldRef for UuidPrimaryKey).