### PR TITLE
feat(migrations): AlterColumn code generation

### DIFF
--- a/packages/jao/CHANGELOG.md
+++ b/packages/jao/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [Unrealesed] - 2026-02-09
+## [Unreleased] - 2026-02-09
 
 ### Added
 
@@ -6,6 +6,16 @@
   - `fieldDefToDbType` now handles `EnumField` annotation
   - Returns `FieldType.integer` when `storeAsInt: true`
   - Returns `FieldType.varchar` for string-based storage (default)
+- Auto-detection of nullability changes in `_generateTableDiff`:
+  - Compares model field nullability with database column nullability
+  - Generates `AlterColumn` operations when nullability differs
+  - Skips primary key fields (SQLite reports PK as nullable even when NOT NULL)
+- `AlterColumn` migration code generation:
+  - Generates `builder.alterColumn()` calls with proper modifiers
+  - Supports nullability changes (`col.nullable()` / `col.notNullable()`)
+  - Supports type changes, default values, and column renames
+  - Generates reverse operations in `down()` for nullability changes
+  - Note: Works with PostgreSQL/MySQL; SQLite requires manual table recreation
 
 ## [0.2.5] - 2026-02-09
 

--- a/packages/jao/lib/src/migrations/generator.dart
+++ b/packages/jao/lib/src/migrations/generator.dart
@@ -418,20 +418,20 @@ class SchemaGenerator {
     final mod = op.modification;
     final modifications = <String>[];
 
-    if (mod.nullable != null) {
-      modifications.add(mod.nullable! ? 'col.nullable()' : 'col.notNullable()');
+    if (mod.nullable case final nullable?) {
+      modifications.add(nullable ? 'col.nullable()' : 'col.notNullable()');
     }
-    if (mod.type != null) {
-      modifications.add('col.setType(FieldType.${mod.type!.name})');
+    if (mod.type case final type?) {
+      modifications.add('col.setType(FieldType.${type.name})');
     }
-    if (mod.defaultValue != null) {
-      modifications.add("col.defaultValue('${mod.defaultValue}')");
+    if (mod.defaultValue case final defaultValue?) {
+      modifications.add("col.defaultValue('${defaultValue}')");
     }
     if (mod.dropDefault) {
       modifications.add('col.dropDefault()');
     }
-    if (mod.rename != null) {
-      modifications.add("col.renameTo('${mod.rename}')");
+    if (mod.rename case final rename?) {
+      modifications.add("col.renameTo('${rename}')");
     }
 
     final buffer = StringBuffer();
@@ -484,8 +484,8 @@ class SchemaGenerator {
         return "${indent}builder.renameColumn('${op.table}', '${op.newName}', '${op.oldName}');";
       case AlterColumn():
         final mod = op.modification;
-        if (mod.nullable != null) {
-          final reverseNullable = !mod.nullable!;
+        if (mod.nullable case final nullable?) {
+          final reverseNullable = !nullable;
           final reverseMethod = reverseNullable ? 'col.nullable()' : 'col.notNullable()';
           return "${indent}builder.alterColumn('${mod.table}', '${mod.column}', (col) {\n$indent  $reverseMethod;\n$indent});";
         }
@@ -499,8 +499,8 @@ class SchemaGenerator {
       case DropConstraint():
         return '$indent// TODO: Cannot reverse DropConstraint - constraint definition lost';
       case RawSql():
-        if (op.reverseSql != null) {
-          return "${indent}builder.raw('${op.reverseSql!.replaceAll("'", "\\'")}');";
+        if (op.reverseSql case final reverseSql?) {
+          return "${indent}builder.raw('${reverseSql.replaceAll("'", "\\'")}');";
         }
         return '$indent// TODO: No reverse SQL provided for RawSql';
       case RunDart():

--- a/packages/jao/lib/src/migrations/generator.dart
+++ b/packages/jao/lib/src/migrations/generator.dart
@@ -304,9 +304,22 @@ class SchemaGenerator {
           );
         }
       } else {
-        // Column exists - check for type/nullability changes
-        // This is more complex and usually requires careful handling
-        // For now, we'll skip auto-detecting type changes
+        // Column exists - check for nullability changes
+        // Skip PK fields: SQLite's PRAGMA table_info reports notnull=0 for
+        // INTEGER PRIMARY KEY even though PKs are implicitly NOT NULL.
+        // PostgreSQL/MySQL report PKs correctly, but this check is harmless there.
+        if (!field.primaryKey && !dbColumn.isPrimaryKey && field.nullable != dbColumn.nullable) {
+          operations.add(
+            AlterColumn(
+              ColumnModification(
+                table: model.tableName,
+                column: field.columnName,
+                nullable: field.nullable,
+              ),
+            ),
+          );
+        }
+        // TODO(mastersam07): Add type change detection (more complex due to type mapping)
       }
     }
 
@@ -357,15 +370,34 @@ class SchemaGenerator {
   }
 
   String _operationToCode(MigrationOperation op, String indent) {
-    if (op is CreateTable) {
-      return _createTableToCode(op, indent);
-    } else if (op is DropTable) {
-      return "${indent}builder.dropTable('${op.name}');";
-    } else if (op is AddColumn) {
-      return "${indent}builder.addColumn('${op.table}', '${op.column.name}', FieldType.${op.column.type.name});";
-    } else if (op is CreateIndex) {
-      final cols = op.index.columns.map((c) => "'$c'").join(', ');
-      return "${indent}builder.createIndex('${op.table}', [$cols], unique: ${op.index.unique});";
+    switch (op) {
+      case CreateTable():
+        return _createTableToCode(op, indent);
+      case DropTable():
+        return "${indent}builder.dropTable('${op.name}');";
+      case RenameTable():
+        return "${indent}builder.renameTable('${op.oldName}', '${op.newName}');";
+      case AddColumn():
+        return "${indent}builder.addColumn('${op.table}', '${op.column.name}', FieldType.${op.column.type.name});";
+      case DropColumn():
+        return "${indent}builder.dropColumn('${op.table}', '${op.column}');";
+      case RenameColumn():
+        return "${indent}builder.renameColumn('${op.table}', '${op.oldName}', '${op.newName}');";
+      case AlterColumn():
+        return _alterColumnToCode(op, indent);
+      case CreateIndex():
+        final cols = op.index.columns.map((c) => "'$c'").join(', ');
+        return "${indent}builder.createIndex('${op.table}', [$cols], unique: ${op.index.unique});";
+      case DropIndex():
+        return "${indent}builder.dropIndex('${op.name}');";
+      case AddForeignKey():
+        return "${indent}builder.addForeignKey('${op.table}', '${op.foreignKey.column}', '${op.foreignKey.referencedTable}', referencedColumn: '${op.foreignKey.referencedColumn}');";
+      case DropConstraint():
+        return "${indent}builder.dropConstraint('${op.table}', '${op.constraintName}');";
+      case RawSql():
+        return "${indent}builder.raw('${op.sql.replaceAll("'", "\\'")}');";
+      case RunDart():
+        return '$indent// RunDart operation - implement manually';
     }
     return '$indent// Unsupported operation: ${op.runtimeType}';
   }
@@ -378,6 +410,35 @@ class SchemaGenerator {
       buffer.writeln(_columnToCode(col, '$indent  '));
     }
 
+    buffer.write('$indent});');
+    return buffer.toString();
+  }
+
+  String _alterColumnToCode(AlterColumn op, String indent) {
+    final mod = op.modification;
+    final modifications = <String>[];
+
+    if (mod.nullable != null) {
+      modifications.add(mod.nullable! ? 'col.nullable()' : 'col.notNullable()');
+    }
+    if (mod.type != null) {
+      modifications.add('col.setType(FieldType.${mod.type!.name})');
+    }
+    if (mod.defaultValue != null) {
+      modifications.add("col.defaultValue('${mod.defaultValue}')");
+    }
+    if (mod.dropDefault) {
+      modifications.add('col.dropDefault()');
+    }
+    if (mod.rename != null) {
+      modifications.add("col.renameTo('${mod.rename}')");
+    }
+
+    final buffer = StringBuffer();
+    buffer.writeln("${indent}builder.alterColumn('${mod.table}', '${mod.column}', (col) {");
+    for (final m in modifications) {
+      buffer.writeln('$indent  $m;');
+    }
     buffer.write('$indent});');
     return buffer.toString();
   }
@@ -408,12 +469,42 @@ class SchemaGenerator {
   }
 
   String? _operationToReverseCode(MigrationOperation op, String indent) {
-    if (op is CreateTable) {
-      return "${indent}builder.dropTable('${op.table.name}');";
-    } else if (op is AddColumn) {
-      return "${indent}builder.dropColumn('${op.table}', '${op.column.name}');";
-    } else if (op is CreateIndex) {
-      return "${indent}builder.dropIndex('${op.index.name}');";
+    switch (op) {
+      case CreateTable():
+        return "${indent}builder.dropTable('${op.table.name}');";
+      case DropTable():
+        return '$indent// TODO: Cannot reverse DropTable - table definition lost';
+      case RenameTable():
+        return "${indent}builder.renameTable('${op.newName}', '${op.oldName}');";
+      case AddColumn():
+        return "${indent}builder.dropColumn('${op.table}', '${op.column.name}');";
+      case DropColumn():
+        return '$indent// TODO: Cannot reverse DropColumn - column definition lost';
+      case RenameColumn():
+        return "${indent}builder.renameColumn('${op.table}', '${op.newName}', '${op.oldName}');";
+      case AlterColumn():
+        final mod = op.modification;
+        if (mod.nullable != null) {
+          final reverseNullable = !mod.nullable!;
+          final reverseMethod = reverseNullable ? 'col.nullable()' : 'col.notNullable()';
+          return "${indent}builder.alterColumn('${mod.table}', '${mod.column}', (col) {\n$indent  $reverseMethod;\n$indent});";
+        }
+        return '$indent// TODO: Manual reversal needed for AlterColumn';
+      case CreateIndex():
+        return "${indent}builder.dropIndex('${op.index.name}');";
+      case DropIndex():
+        return '$indent// TODO: Cannot reverse DropIndex - index definition lost';
+      case AddForeignKey():
+        return "${indent}builder.dropConstraint('${op.table}', 'fk_${op.table}_${op.foreignKey.column}');";
+      case DropConstraint():
+        return '$indent// TODO: Cannot reverse DropConstraint - constraint definition lost';
+      case RawSql():
+        if (op.reverseSql != null) {
+          return "${indent}builder.raw('${op.reverseSql!.replaceAll("'", "\\'")}');";
+        }
+        return '$indent// TODO: No reverse SQL provided for RawSql';
+      case RunDart():
+        return '$indent// TODO: Cannot reverse RunDart operation';
     }
     return null;
   }

--- a/packages/jao/test/migrations/schema_generator_test.dart
+++ b/packages/jao/test/migrations/schema_generator_test.dart
@@ -711,6 +711,112 @@ void main() {
           expect(createTables.length, equals(2));
         });
       });
+
+      test('generates AlterColumn for nullability change (non-nullable to nullable)', () async {
+        await pool.withConnection((conn) async {
+          // Create table with a NOT NULL column
+          await conn.execute('''
+            CREATE TABLE IF NOT EXISTS nullable_test (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              name TEXT NOT NULL
+            )
+          ''');
+
+          // Model with nullable=true for name
+          const schema = ModelSchema(
+            className: 'NullableTest',
+            tableName: 'nullable_test',
+            fields: [
+              ModelFieldSchema(
+                name: 'id',
+                columnName: 'id',
+                dbType: FieldType.serial,
+                primaryKey: true,
+                autoIncrement: true,
+              ),
+              ModelFieldSchema(name: 'name', columnName: 'name', dbType: FieldType.text, nullable: true),
+            ],
+          );
+
+          final operations = await generator.generateDiff(conn, [schema]);
+
+          expect(operations.any((op) => op is AlterColumn), isTrue);
+          final alterColumn = operations.whereType<AlterColumn>().first;
+          expect(alterColumn.modification.table, equals('nullable_test'));
+          expect(alterColumn.modification.column, equals('name'));
+          expect(alterColumn.modification.nullable, isTrue);
+        });
+      });
+
+      test('generates AlterColumn for nullability change (nullable to non-nullable)', () async {
+        await pool.withConnection((conn) async {
+          // Create table with a nullable column (no NOT NULL)
+          await conn.execute('''
+            CREATE TABLE IF NOT EXISTS notnull_test (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              description TEXT
+            )
+          ''');
+
+          // Model with nullable=false for description
+          const schema = ModelSchema(
+            className: 'NotNullTest',
+            tableName: 'notnull_test',
+            fields: [
+              ModelFieldSchema(
+                name: 'id',
+                columnName: 'id',
+                dbType: FieldType.serial,
+                primaryKey: true,
+                autoIncrement: true,
+              ),
+              ModelFieldSchema(name: 'description', columnName: 'description', dbType: FieldType.text, nullable: false),
+            ],
+          );
+
+          final operations = await generator.generateDiff(conn, [schema]);
+
+          expect(operations.any((op) => op is AlterColumn), isTrue);
+          final alterColumn = operations.whereType<AlterColumn>().first;
+          expect(alterColumn.modification.table, equals('notnull_test'));
+          expect(alterColumn.modification.column, equals('description'));
+          expect(alterColumn.modification.nullable, isFalse);
+        });
+      });
+
+      test('does not generate AlterColumn for PK fields (SQLite quirk)', () async {
+        await pool.withConnection((conn) async {
+          // Create table - SQLite reports INTEGER PRIMARY KEY as nullable=true in PRAGMA
+          await conn.execute('''
+            CREATE TABLE IF NOT EXISTS pk_null_test (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              name TEXT NOT NULL
+            )
+          ''');
+
+          // Model with PK marked as non-nullable (which is correct)
+          const schema = ModelSchema(
+            className: 'PkNullTest',
+            tableName: 'pk_null_test',
+            fields: [
+              ModelFieldSchema(
+                name: 'id',
+                columnName: 'id',
+                dbType: FieldType.serial,
+                primaryKey: true,
+                autoIncrement: true,
+                // nullable defaults to false
+              ),
+              ModelFieldSchema(name: 'name', columnName: 'name', dbType: FieldType.text),
+            ],
+          );
+
+          final operations = await generator.generateDiff(conn, [schema]);
+
+          // Should not detect a nullability change for PK
+          expect(operations.whereType<AlterColumn>().isEmpty, isTrue);
+        });
+      });
     });
 
     group('generateMigrationFile()', () {
@@ -820,6 +926,181 @@ void main() {
         final content = generator.generateMigrationFile('CreateLogsTable', operations);
 
         expect(content, contains('useCurrent: true'));
+      });
+
+      test('generates DropTable operation', () {
+        final operations = [const DropTable('old_table')];
+
+        final content = generator.generateMigrationFile('DropOldTable', operations);
+
+        expect(content, contains("builder.dropTable('old_table')"));
+      });
+
+      test('generates RenameTable operation', () {
+        final operations = [const RenameTable('old_name', 'new_name')];
+
+        final content = generator.generateMigrationFile('RenameOldTable', operations);
+
+        expect(content, contains("builder.renameTable('old_name', 'new_name')"));
+        // Reverse should swap the names
+        expect(content, contains("builder.renameTable('new_name', 'old_name')"));
+      });
+
+      test('generates DropColumn operation', () {
+        final operations = [const DropColumn('users', 'deprecated_field')];
+
+        final content = generator.generateMigrationFile('DropDeprecatedField', operations);
+
+        expect(content, contains("builder.dropColumn('users', 'deprecated_field')"));
+      });
+
+      test('generates RenameColumn operation', () {
+        final operations = [const RenameColumn('users', 'old_col', 'new_col')];
+
+        final content = generator.generateMigrationFile('RenameUserColumn', operations);
+
+        expect(content, contains("builder.renameColumn('users', 'old_col', 'new_col')"));
+        // Reverse should swap the names
+        expect(content, contains("builder.renameColumn('users', 'new_col', 'old_col')"));
+      });
+
+      test('generates AlterColumn with nullable change', () {
+        final operations = [
+          AlterColumn(ColumnModification(table: 'users', column: 'bio', nullable: true)),
+        ];
+
+        final content = generator.generateMigrationFile('MakeBioNullable', operations);
+
+        expect(content, contains("builder.alterColumn('users', 'bio', (col) {"));
+        expect(content, contains('col.nullable();'));
+        // Reverse should use notNullable
+        expect(content, contains('col.notNullable();'));
+      });
+
+      test('generates AlterColumn with notNullable change', () {
+        final operations = [
+          AlterColumn(ColumnModification(table: 'users', column: 'email', nullable: false)),
+        ];
+
+        final content = generator.generateMigrationFile('MakeEmailRequired', operations);
+
+        expect(content, contains("builder.alterColumn('users', 'email', (col) {"));
+        expect(content, contains('col.notNullable();'));
+        // Reverse should use nullable
+        expect(content, contains('col.nullable();'));
+      });
+
+      test('generates AlterColumn with type change', () {
+        final operations = [
+          AlterColumn(ColumnModification(table: 'products', column: 'price', type: FieldType.decimal)),
+        ];
+
+        final content = generator.generateMigrationFile('ChangePrice', operations);
+
+        expect(content, contains("builder.alterColumn('products', 'price', (col) {"));
+        expect(content, contains('col.setType(FieldType.decimal)'));
+      });
+
+      test('generates AlterColumn with default value', () {
+        final operations = [
+          AlterColumn(ColumnModification(table: 'settings', column: 'is_active', defaultValue: 'true')),
+        ];
+
+        final content = generator.generateMigrationFile('SetDefaultActive', operations);
+
+        expect(content, contains("builder.alterColumn('settings', 'is_active', (col) {"));
+        expect(content, contains("col.defaultValue('true')"));
+      });
+
+      test('generates AlterColumn with drop default', () {
+        final operations = [
+          AlterColumn(ColumnModification(table: 'settings', column: 'theme', dropDefault: true)),
+        ];
+
+        final content = generator.generateMigrationFile('DropThemeDefault', operations);
+
+        expect(content, contains("builder.alterColumn('settings', 'theme', (col) {"));
+        expect(content, contains('col.dropDefault()'));
+      });
+
+      test('generates AlterColumn with rename', () {
+        final operations = [
+          AlterColumn(ColumnModification(table: 'users', column: 'name', rename: 'full_name')),
+        ];
+
+        final content = generator.generateMigrationFile('RenameNameColumn', operations);
+
+        expect(content, contains("builder.alterColumn('users', 'name', (col) {"));
+        expect(content, contains("col.renameTo('full_name')"));
+      });
+
+      test('generates DropIndex operation', () {
+        final operations = [const DropIndex('idx_users_email')];
+
+        final content = generator.generateMigrationFile('DropEmailIndex', operations);
+
+        expect(content, contains("builder.dropIndex('idx_users_email')"));
+      });
+
+      test('generates AddForeignKey operation', () {
+        final operations = [
+          const AddForeignKey(
+            'posts',
+            ForeignKeyDefinition(
+              column: 'author_id',
+              referencedTable: 'users',
+              referencedColumn: 'id',
+            ),
+          ),
+        ];
+
+        final content = generator.generateMigrationFile('AddAuthorFK', operations);
+
+        expect(content, contains("builder.addForeignKey('posts', 'author_id', 'users', referencedColumn: 'id')"));
+        // Reverse should drop the constraint
+        expect(content, contains("builder.dropConstraint('posts', 'fk_posts_author_id')"));
+      });
+
+      test('generates DropConstraint operation', () {
+        final operations = [const DropConstraint('orders', 'fk_orders_user_id')];
+
+        final content = generator.generateMigrationFile('DropUserFK', operations);
+
+        expect(content, contains("builder.dropConstraint('orders', 'fk_orders_user_id')"));
+      });
+
+      test('generates RawSql operation', () {
+        final operations = [const RawSql('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"')];
+
+        final content = generator.generateMigrationFile('AddUuidExtension', operations);
+
+        expect(content, contains("builder.raw('CREATE EXTENSION IF NOT EXISTS"));
+      });
+
+      test('generates RawSql with reverse', () {
+        final operations = [
+          const RawSql(
+            'CREATE MATERIALIZED VIEW stats AS SELECT COUNT(*) FROM users',
+            reverseSql: 'DROP MATERIALIZED VIEW stats',
+          ),
+        ];
+
+        final content = generator.generateMigrationFile('CreateStatsView', operations);
+
+        expect(content, contains('CREATE MATERIALIZED VIEW stats'));
+        expect(content, contains('DROP MATERIALIZED VIEW stats'));
+      });
+
+      test('generates RunDart operation', () {
+        final operations = [
+          RunDart((conn) async {
+            // Migrate data
+          }),
+        ];
+
+        final content = generator.generateMigrationFile('MigrateData', operations);
+
+        expect(content, contains('// RunDart operation - implement manually'));
       });
 
       test('generates nullable column', () {


### PR DESCRIPTION
- Detect nullability changes in _generateTableDiff and generate AlterColumn ops
- Skip PK fields in nullability check (SQLite PRAGMA quirk workaround)
- Implement _alterColumnToCode for all modification types
- Handle all 13 MigrationOperation types in _operationToCode
- Generate reversible down() migrations for nullability changes
- Add TODO comments for irreversible operations (DropTable, DropColumn, etc.)