### PR TITLE
fix: generate UUID primary key column in migrations

### DIFF
--- a/packages/jao/lib/src/migrations/generator.dart
+++ b/packages/jao/lib/src/migrations/generator.dart
@@ -140,6 +140,11 @@ class SchemaGenerator {
       return;
     }
 
+    if (field.primaryKey && field.dbType == FieldType.uuid) {
+      builder.uuid(field.columnName);
+      return;
+    }
+
     switch (field.dbType) {
       case FieldType.varchar:
         builder.string(
@@ -156,19 +161,22 @@ class SchemaGenerator {
       case FieldType.integer:
       case FieldType.smallInt:
       case FieldType.bigInt:
-        if (field.foreignKey != null) {
+        if (field.foreignKey case final fk?) {
           builder.foreignKey(
             field.columnName,
-            field.foreignKey!.referencedTable,
-            referencedColumn: field.foreignKey!.referencedColumn,
-            onDelete: field.foreignKey!.onDelete,
+            fk.referencedTable,
+            referencedColumn: fk.referencedColumn,
+            onDelete: fk.onDelete,
             nullable: field.nullable,
           );
         } else {
           builder.integer(
             field.columnName,
             nullable: field.nullable,
-            defaultValue: field.defaultValue != null ? int.tryParse(field.defaultValue!) : null,
+            defaultValue: switch (field.defaultValue) {
+              final value? => int.tryParse(value),
+              _ => null,
+            },
           );
         }
 
@@ -176,13 +184,19 @@ class SchemaGenerator {
         builder.float(
           field.columnName,
           nullable: field.nullable,
-          defaultValue: field.defaultValue != null ? double.tryParse(field.defaultValue!) : null,
+          defaultValue: switch (field.defaultValue) {
+            final value? => double.tryParse(value),
+            _ => null,
+          },
         );
       case FieldType.doublePrecision:
         builder.doublePrecision(
           field.columnName,
           nullable: field.nullable,
-          defaultValue: field.defaultValue != null ? double.tryParse(field.defaultValue!) : null,
+          defaultValue: switch (field.defaultValue) {
+            final value? => double.tryParse(value),
+            _ => null,
+          },
         );
 
       case FieldType.decimal:
@@ -198,7 +212,10 @@ class SchemaGenerator {
         builder.boolean(
           field.columnName,
           nullable: field.nullable,
-          defaultValue: field.defaultValue != null ? field.defaultValue!.toLowerCase() == 'true' : null,
+          defaultValue: switch (field.defaultValue) {
+            final value? => value.toLowerCase() == 'true',
+            _ => null,
+          },
         );
 
       case FieldType.date:
@@ -224,7 +241,6 @@ class SchemaGenerator {
         builder.binary(field.columnName, nullable: field.nullable);
 
       default:
-        // Fallback to text
         builder.text(field.columnName, nullable: field.nullable);
     }
   }

--- a/packages/jao/lib/src/migrations/schema.dart
+++ b/packages/jao/lib/src/migrations/schema.dart
@@ -23,7 +23,7 @@ class TableBuilder {
     return this;
   }
 
-  // === Primary Key Columns ===
+  // Primary Key Columns
 
   /// Auto-incrementing integer primary key
   TableBuilder id([String name = 'id']) {
@@ -39,7 +39,7 @@ class TableBuilder {
     return this;
   }
 
-  /// UUID primary key
+  /// UUID primary key (UUID is generated in Dart by the executor)
   TableBuilder uuid([String name = 'id']) {
     _columns.add(
       ColumnDefinition(
@@ -47,14 +47,13 @@ class TableBuilder {
         type: FieldType.uuid,
         nullable: false,
         primaryKey: true,
-        defaultValue: 'gen_random_uuid()', // PostgreSQL
       ),
     );
     _primaryKey = name;
     return this;
   }
 
-  // === String Columns ===
+  // String Columns
 
   /// VARCHAR column
   TableBuilder string(String name, {int length = 255, bool nullable = false, String? defaultValue}) {
@@ -90,7 +89,7 @@ class TableBuilder {
     return this;
   }
 
-  // === Numeric Columns ===
+  // Numeric Columns
 
   /// INTEGER column
   TableBuilder integer(String name, {bool nullable = false, int? defaultValue}) {
@@ -157,7 +156,7 @@ class TableBuilder {
     return this;
   }
 
-  // === Boolean ===
+  // Boolean
 
   /// BOOLEAN column
   TableBuilder boolean(String name, {bool nullable = false, bool? defaultValue}) {
@@ -167,7 +166,7 @@ class TableBuilder {
     return this;
   }
 
-  // === Date/Time Columns ===
+  // Date/Time Columns
 
   /// DATE column
   TableBuilder date(String name, {bool nullable = false, String? defaultValue}) {
@@ -224,7 +223,7 @@ class TableBuilder {
     return this;
   }
 
-  // === Special Types ===
+  // Special Types
 
   /// BYTEA/BLOB column
   TableBuilder binary(String name, {bool nullable = false}) {
@@ -250,7 +249,7 @@ class TableBuilder {
     return this;
   }
 
-  // === Enum ===
+  // Enum
 
   /// Enum column (stored as string)
   TableBuilder enumString(String name, List<String> values, {bool nullable = false, String? defaultValue}) {
@@ -268,7 +267,7 @@ class TableBuilder {
     return this;
   }
 
-  // === Foreign Keys ===
+  // Foreign Keys
 
   /// Foreign key reference to another table
   TableBuilder foreignKey(
@@ -320,7 +319,7 @@ class TableBuilder {
     return this;
   }
 
-  // === Indexes ===
+  // Indexes
 
   /// Create an index on one or more columns
   TableBuilder index(List<String> columns, {String? name, bool unique = false}) {
@@ -340,7 +339,7 @@ class TableBuilder {
     return index([column], unique: true);
   }
 
-  // === Soft Delete ===
+  // Soft Delete
 
   /// Add soft delete columns (is_deleted, deleted_at)
   TableBuilder softDeletes() {
@@ -349,7 +348,7 @@ class TableBuilder {
     return this;
   }
 
-  // === Build ===
+  // Build
 
   /// Build the table definition
   TableDefinition build() {
@@ -444,7 +443,7 @@ class TableDefinition {
   });
 }
 
-// === Column Modification Builder ===
+// Column Modification Builder
 
 /// Builder for modifying an existing column.
 class ColumnModifier {

--- a/packages/jao/test/migrations/schema_generator_test.dart
+++ b/packages/jao/test/migrations/schema_generator_test.dart
@@ -269,6 +269,49 @@ void main() {
         expect(createTable.table.columns.length, equals(12));
       });
 
+      test('generates CreateTable with UuidPrimaryKey', () {
+        const schema = ModelSchema(
+          className: 'Merchant',
+          tableName: 'merchants',
+          fields: [
+            ModelFieldSchema(
+              name: 'id',
+              columnName: 'id',
+              dbType: FieldType.uuid,
+              primaryKey: true,
+            ),
+            ModelFieldSchema(name: 'name', columnName: 'name', dbType: FieldType.varchar, maxLength: 100),
+            ModelFieldSchema(
+                name: 'email', columnName: 'email', dbType: FieldType.varchar, maxLength: 254, unique: true),
+            ModelFieldSchema(
+              name: 'createdAt',
+              columnName: 'created_at',
+              dbType: FieldType.timestampTz,
+              defaultValue: 'CURRENT_TIMESTAMP',
+            ),
+          ],
+        );
+
+        final operations = generator.generateCreateTable(schema);
+
+        expect(operations.length, equals(1));
+        final createTable = operations[0] as CreateTable;
+        final table = createTable.table;
+
+        // The id column should exist
+        final idColumn = table.columns.where((c) => c.name == 'id').firstOrNull;
+        expect(idColumn, isNotNull, reason: 'UUID primary key column should be created');
+
+        // The id column should be a UUID type
+        expect(idColumn!.type, equals(FieldType.uuid));
+
+        // The id column should be marked as primary key
+        expect(idColumn.primaryKey, isTrue, reason: 'UUID column should be marked as primary key');
+
+        // The table should have the id as its primary key
+        expect(table.primaryKey, equals('id'), reason: 'Table primary key should be set to id');
+      });
+
       test('generates CreateTable with bigId primary key', () {
         const schema = ModelSchema(
           className: 'BigModel',

--- a/packages/jao/test/migrations/table_builder_test.dart
+++ b/packages/jao/test/migrations/table_builder_test.dart
@@ -36,7 +36,7 @@ void main() {
         final idCol = table.columns.first;
         expect(idCol.type, equals(FieldType.uuid));
         expect(idCol.primaryKey, isTrue);
-        expect(idCol.defaultValue, isNotNull);
+        expect(idCol.defaultValue, isNull);
       });
     });
 


### PR DESCRIPTION
The schema generator skipped `UUID` primary key fields because they have `primaryKey: true` but `autoIncrement: false`, falling through to `uuidColumn()` which doesn't set the `primary key constraint`.



Added explicit handling for `UUID` PKs and removed the Postgres-specific `gen_random_uuid()` default since UUIDs are generated in Dart.

Closes #33 .