### PR TITLE
fix: emit missing schema attributes in generator

### DIFF
--- a/packages/jao_generator/lib/src/generator.dart
+++ b/packages/jao_generator/lib/src/generator.dart
@@ -51,6 +51,11 @@ class JaoGenerator extends GeneratorForAnnotation<Model> {
             relation: fieldAnnotation.relation,
             isEnum: fieldAnnotation.isEnum,
             storeEnumAsInt: fieldAnnotation.storeEnumAsInt,
+            maxLength: fieldAnnotation.maxLength,
+            unique: fieldAnnotation.unique,
+            precision: fieldAnnotation.precision,
+            scale: fieldAnnotation.scale,
+            onDelete: fieldAnnotation.onDelete,
           ),
         );
       } else {
@@ -95,32 +100,36 @@ class JaoGenerator extends GeneratorForAnnotation<Model> {
       final typeName = type.getDisplayString();
       final baseTypeName = typeName.contains('<') ? typeName.substring(0, typeName.indexOf('<')) : typeName;
       final defaultValue = _extractDefaultValue(value.getField('defaultValue'));
+      final unique = value.getField('unique')?.toBoolValue() ?? false;
 
       switch (baseTypeName) {
         case 'CharField':
+          final maxLength = value.getField('maxLength')?.toIntValue();
           return _FieldAnnotationInfo('String', 'StringFieldRef', 'varchar', annotation.toSource(),
-              defaultValue: defaultValue);
+              defaultValue: defaultValue, unique: unique, maxLength: maxLength);
         case 'TextField':
           return _FieldAnnotationInfo('String', 'StringFieldRef', 'text', annotation.toSource(),
-              defaultValue: defaultValue);
+              defaultValue: defaultValue, unique: unique);
         case 'EmailField':
+          final maxLength = value.getField('maxLength')?.toIntValue();
           return _FieldAnnotationInfo('String', 'StringFieldRef', 'varchar', annotation.toSource(),
-              defaultValue: defaultValue);
+              defaultValue: defaultValue, unique: unique, maxLength: maxLength);
         case 'UrlField':
+          final maxLength = value.getField('maxLength')?.toIntValue();
           return _FieldAnnotationInfo('String', 'StringFieldRef', 'varchar', annotation.toSource(),
-              defaultValue: defaultValue);
+              defaultValue: defaultValue, unique: unique, maxLength: maxLength);
         case 'IntegerField':
           return _FieldAnnotationInfo('int', 'IntFieldRef', 'integer', annotation.toSource(),
-              defaultValue: defaultValue);
+              defaultValue: defaultValue, unique: unique);
         case 'SmallIntegerField':
           return _FieldAnnotationInfo('int', 'IntFieldRef', 'smallInt', annotation.toSource(),
-              defaultValue: defaultValue);
+              defaultValue: defaultValue, unique: unique);
         case 'BigIntegerField':
           return _FieldAnnotationInfo('int', 'IntFieldRef', 'bigInt', annotation.toSource(),
-              defaultValue: defaultValue);
+              defaultValue: defaultValue, unique: unique);
         case 'PositiveIntegerField':
           return _FieldAnnotationInfo('int', 'IntFieldRef', 'integer', annotation.toSource(),
-              defaultValue: defaultValue);
+              defaultValue: defaultValue, unique: unique);
         case 'AutoField':
           return _FieldAnnotationInfo(
             'int',
@@ -141,16 +150,27 @@ class JaoGenerator extends GeneratorForAnnotation<Model> {
           );
         case 'FloatField':
           return _FieldAnnotationInfo('double', 'DoubleFieldRef', 'real', annotation.toSource(),
-              defaultValue: defaultValue);
+              defaultValue: defaultValue, unique: unique);
         case 'DecimalField':
+          final maxDigits = value.getField('maxDigits')?.toIntValue();
+          final decimalPlaces = value.getField('decimalPlaces')?.toIntValue();
           return _FieldAnnotationInfo('double', 'DoubleFieldRef', 'decimal', annotation.toSource(),
-              defaultValue: defaultValue);
+              defaultValue: defaultValue, unique: unique, precision: maxDigits, scale: decimalPlaces);
         case 'BooleanField':
           return _FieldAnnotationInfo('bool', 'BoolFieldRef', 'boolean', annotation.toSource(),
               defaultValue: defaultValue);
         case 'DateField':
-          return _FieldAnnotationInfo('DateTime', 'DateTimeFieldRef', 'date', annotation.toSource(),
-              defaultValue: defaultValue);
+          final dateAutoNowAdd = value.getField('autoNowAdd')?.toBoolValue() ?? false;
+          final dateAutoNow = value.getField('autoNow')?.toBoolValue() ?? false;
+          return _FieldAnnotationInfo(
+            'DateTime',
+            'DateTimeFieldRef',
+            'date',
+            annotation.toSource(),
+            autoNowAdd: dateAutoNowAdd,
+            autoNow: dateAutoNow,
+            defaultValue: defaultValue,
+          );
         case 'DateTimeField':
           final autoNowAdd = value.getField('autoNowAdd')?.toBoolValue() ?? false;
           final autoNow = value.getField('autoNow')?.toBoolValue() ?? false;
@@ -187,11 +207,20 @@ class JaoGenerator extends GeneratorForAnnotation<Model> {
             _ => _RelationType.foreignKey,
           };
           final (pkType, pkFieldRef, pkDbType) = _resolvePkType(relatedDartType);
+          final onDeleteField = value.getField('onDelete');
+          String? onDeleteValue;
+          if (onDeleteField case final onDeleteField? when !onDeleteField.isNull) {
+            final enumIndex = onDeleteField.getField('index')?.toIntValue();
+            if (enumIndex case final enumIndex? when enumIndex >= 0) {
+              onDeleteValue = const ['cascade', 'restrict', 'setNull', 'setDefault', 'noAction'][enumIndex];
+            }
+          }
           return _FieldAnnotationInfo(
             pkType,
             pkFieldRef,
             pkDbType,
             annotation.toSource(),
+            onDelete: onDeleteValue,
             relation: relatedModel != null && relatedTable != null
                 ? _RelationInfo(
                     relatedModel: relatedModel,
@@ -210,6 +239,7 @@ class JaoGenerator extends GeneratorForAnnotation<Model> {
             annotation.toSource(),
             autoGenerateUuid: autoGenerate,
             defaultValue: defaultValue,
+            unique: unique,
           );
         case 'UuidPrimaryKey':
           return _FieldAnnotationInfo(
@@ -236,6 +266,7 @@ class JaoGenerator extends GeneratorForAnnotation<Model> {
             storeAsInt ? 'integer' : 'varchar',
             annotation.toSource(),
             defaultValue: defaultValue,
+            unique: unique,
             isEnum: true,
             storeEnumAsInt: storeAsInt,
           );
@@ -448,10 +479,27 @@ class JaoGenerator extends GeneratorForAnnotation<Model> {
       buffer.writeln('        autoIncrement: ${field.autoIncrement},');
       buffer.writeln('        autoNowAdd: ${field.autoNowAdd},');
       buffer.writeln('        autoNow: ${field.autoNow},');
+      if (field.unique) {
+        buffer.writeln('        unique: true,');
+      }
+      if (field.maxLength case final maxLength?) {
+        buffer.writeln('        maxLength: $maxLength,');
+      }
+      if (field.precision case final precision?) {
+        buffer.writeln('        precision: $precision,');
+      }
+      if (field.scale case final scale?) {
+        buffer.writeln('        scale: $scale,');
+      }
+      if (field.defaultValue case final defaultValue?) {
+        buffer.writeln("        defaultValue: $defaultValue,");
+      }
       if (field.relation case final relation?) {
+        final onDelete = field.onDelete ?? 'cascade';
         buffer.writeln('        foreignKey: ForeignKeyInfo(');
         buffer.writeln("          referencedTable: '${relation.relatedTable}',");
         buffer.writeln("          referencedColumn: '${relation.relatedColumn}',");
+        buffer.writeln('          onDelete: OnDeleteAction.$onDelete,');
         buffer.writeln('        ),');
       }
       buffer.writeln('      ),');
@@ -637,6 +685,11 @@ class _FieldInfo {
   final _RelationInfo? relation;
   final bool isEnum;
   final bool storeEnumAsInt;
+  final int? maxLength;
+  final bool unique;
+  final int? precision;
+  final int? scale;
+  final String? onDelete;
 
   _FieldInfo({
     required this.name,
@@ -654,6 +707,11 @@ class _FieldInfo {
     this.relation,
     this.isEnum = false,
     this.storeEnumAsInt = false,
+    this.maxLength,
+    this.unique = false,
+    this.precision,
+    this.scale,
+    this.onDelete,
   });
 }
 
@@ -687,6 +745,11 @@ class _FieldAnnotationInfo {
   final _RelationInfo? relation;
   final bool isEnum;
   final bool storeEnumAsInt;
+  final int? maxLength;
+  final bool unique;
+  final int? precision;
+  final int? scale;
+  final String? onDelete;
 
   _FieldAnnotationInfo(
     this.type,
@@ -702,5 +765,10 @@ class _FieldAnnotationInfo {
     this.relation,
     this.isEnum = false,
     this.storeEnumAsInt = false,
+    this.maxLength,
+    this.unique = false,
+    this.precision,
+    this.scale,
+    this.onDelete,
   });
 }

--- a/packages/jao_generator/test/generator/generator_test.dart
+++ b/packages/jao_generator/test/generator/generator_test.dart
@@ -370,6 +370,140 @@ class User {
       expect(result, contains("static const pkField = 'id'"));
     });
 
+    test('emits maxLength in ModelFieldSchema for CharField', () async {
+      final result = await _generateForSource(generator, '''
+@Model()
+class User {
+  @AutoField()
+  late int id;
+  @CharField(maxLength: 100)
+  late String name;
+}
+''');
+
+      expect(result, contains('maxLength: 100'));
+    });
+
+    test('emits maxLength in ModelFieldSchema for EmailField', () async {
+      final result = await _generateForSource(generator, '''
+@Model()
+class User {
+  @AutoField()
+  late int id;
+  @EmailField(unique: true)
+  late String email;
+}
+''');
+
+      expect(result, contains('maxLength: 254'));
+      expect(result, contains('unique: true'));
+    });
+
+    test('emits unique constraint in ModelFieldSchema', () async {
+      final result = await _generateForSource(generator, '''
+@Model()
+class User {
+  @AutoField()
+  late int id;
+  @CharField(maxLength: 255, unique: true)
+  late String username;
+}
+''');
+
+      expect(result, contains('unique: true'));
+    });
+
+    test('emits defaultValue in ModelFieldSchema for BooleanField', () async {
+      final result = await _generateForSource(generator, '''
+@Model()
+class User {
+  @AutoField()
+  late int id;
+  @BooleanField(defaultValue: false)
+  late bool isActive;
+}
+''');
+
+      expect(result, contains('defaultValue: false'));
+    });
+
+    test('emits defaultValue in ModelFieldSchema for CharField', () async {
+      final result = await _generateForSource(generator, '''
+@Model()
+class User {
+  @AutoField()
+  late int id;
+  @CharField(maxLength: 20, defaultValue: 'production')
+  late String target;
+}
+''');
+
+      expect(result, contains("defaultValue: 'production'"));
+    });
+
+    test('emits defaultValue in ModelFieldSchema for TextField', () async {
+      final result = await _generateForSource(generator, '''
+@Model()
+class User {
+  @AutoField()
+  late int id;
+  @TextField(defaultValue: '{}')
+  late String meta;
+}
+''');
+
+      expect(result, contains("defaultValue: '{}'"));
+    });
+
+    test('emits precision and scale in ModelFieldSchema for DecimalField', () async {
+      final result = await _generateForSource(generator, '''
+@Model()
+class Product {
+  @AutoField()
+  late int id;
+  @DecimalField(maxDigits: 12, decimalPlaces: 4)
+  late double price;
+}
+''');
+
+      expect(result, contains('precision: 12'));
+      expect(result, contains('scale: 4'));
+    });
+
+    test('emits onDelete in ForeignKeyInfo', () async {
+      final result = await _generateForSource(generator, '''
+@Model()
+class Post {
+  @AutoField()
+  late int id;
+  @ForeignKey(User, onDelete: OnDelete.cascade)
+  late int userId;
+}
+
+class User {}
+''');
+
+      expect(result, contains('onDelete: OnDeleteAction.cascade'));
+    });
+
+    test('emits ForeignKeyInfo with referencedTable and referencedColumn', () async {
+      final result = await _generateForSource(generator, '''
+@Model()
+class Post {
+  @AutoField()
+  late int id;
+  @ForeignKey(User)
+  late int userId;
+}
+
+class User {}
+''');
+
+      expect(result, contains("referencedTable: 'user'"));
+      expect(result, contains("referencedColumn: 'id'"));
+      expect(result, contains('onDelete: OnDeleteAction.cascade'));
+    });
+
     test('skips static fields', () async {
       final result = await _generateForSource(generator, '''
 @Model()
@@ -404,93 +538,138 @@ class BigAutoField {
 
 class CharField {
   final int maxLength;
-  const CharField({this.maxLength = 255});
+  final bool unique;
+  final Object? defaultValue;
+  const CharField({this.maxLength = 255, this.unique = false, this.defaultValue});
 }
 
 class TextField {
-  const TextField();
+  final bool unique;
+  final Object? defaultValue;
+  const TextField({this.unique = false, this.defaultValue});
 }
 
 class EmailField {
   final int maxLength;
-  const EmailField({this.maxLength = 254});
+  final bool unique;
+  final Object? defaultValue;
+  const EmailField({this.maxLength = 254, this.unique = false, this.defaultValue});
 }
 
 class UrlField {
   final int maxLength;
-  const UrlField({this.maxLength = 200});
+  final bool unique;
+  final Object? defaultValue;
+  const UrlField({this.maxLength = 2048, this.unique = false, this.defaultValue});
 }
 
 class IntegerField {
-  const IntegerField();
+  final bool unique;
+  final Object? defaultValue;
+  const IntegerField({this.unique = false, this.defaultValue});
 }
 
 class SmallIntegerField {
-  const SmallIntegerField();
+  final bool unique;
+  final Object? defaultValue;
+  const SmallIntegerField({this.unique = false, this.defaultValue});
 }
 
 class BigIntegerField {
-  const BigIntegerField();
+  final bool unique;
+  final Object? defaultValue;
+  const BigIntegerField({this.unique = false, this.defaultValue});
 }
 
 class PositiveIntegerField {
-  const PositiveIntegerField();
+  final bool unique;
+  final Object? defaultValue;
+  const PositiveIntegerField({this.unique = false, this.defaultValue});
 }
 
 class FloatField {
-  const FloatField();
+  final bool unique;
+  final Object? defaultValue;
+  const FloatField({this.unique = false, this.defaultValue});
 }
 
 class DecimalField {
   final int maxDigits;
   final int decimalPlaces;
-  const DecimalField({this.maxDigits = 10, this.decimalPlaces = 2});
+  final bool unique;
+  final Object? defaultValue;
+  const DecimalField({this.maxDigits = 10, this.decimalPlaces = 2, this.unique = false, this.defaultValue});
 }
 
 class BooleanField {
-  const BooleanField();
+  final Object? defaultValue;
+  const BooleanField({this.defaultValue});
 }
 
 class DateField {
   final bool autoNowAdd;
   final bool autoNow;
-  const DateField({this.autoNowAdd = false, this.autoNow = false});
+  final Object? defaultValue;
+  const DateField({this.autoNowAdd = false, this.autoNow = false, this.defaultValue});
 }
 
 class DateTimeField {
   final bool autoNowAdd;
   final bool autoNow;
-  const DateTimeField({this.autoNowAdd = false, this.autoNow = false});
+  final Object? defaultValue;
+  const DateTimeField({this.autoNowAdd = false, this.autoNow = false, this.defaultValue});
 }
 
 class DurationField {
-  const DurationField();
+  final Object? defaultValue;
+  const DurationField({this.defaultValue});
 }
 
 class TimeField {
-  const TimeField();
+  final Object? defaultValue;
+  const TimeField({this.defaultValue});
 }
 
 class UuidField {
-  const UuidField();
+  final bool autoGenerate;
+  final bool unique;
+  final Object? defaultValue;
+  const UuidField({this.autoGenerate = false, this.unique = false, this.defaultValue});
+}
+
+class UuidPrimaryKey {
+  const UuidPrimaryKey();
 }
 
 class JsonField {
-  const JsonField();
+  final Object? defaultValue;
+  const JsonField({this.defaultValue});
 }
 
 class BinaryField {
   const BinaryField();
 }
 
+enum OnDelete { cascade, protect, setNull, setDefault, doNothing }
+
 class ForeignKey {
   final Type to;
-  const ForeignKey(this.to);
+  final OnDelete onDelete;
+  final bool unique;
+  const ForeignKey(this.to, {this.onDelete = OnDelete.cascade, this.unique = false});
 }
 
 class OneToOneField {
   final Type to;
-  const OneToOneField(this.to);
+  final OnDelete onDelete;
+  const OneToOneField(this.to, {this.onDelete = OnDelete.cascade});
+}
+
+class EnumField<T> {
+  final bool storeAsInt;
+  final bool unique;
+  final Object? defaultValue;
+  const EnumField({this.storeAsInt = false, this.unique = false, this.defaultValue});
 }
 ''';
 


### PR DESCRIPTION
The code generator was not passing these annotation attributes through to the generated ModelFieldSchema, causing migrations to lose defaults, string lengths, unique constraints, decimal precision, and FK actions.
