### PR TITLE
fix: detect default, unique, FK, and length changes on existing columns in migration diff

### DIFF
--- a/packages/jao/lib/src/migrations/generator.dart
+++ b/packages/jao/lib/src/migrations/generator.dart
@@ -357,6 +357,91 @@ class SchemaGenerator {
             );
           }
         }
+
+        // Check for default value changes
+        if (_defaultValuesDiffer(field.defaultValue, dbColumn.defaultValue)) {
+          if (field.defaultValue case final defaultValue?) {
+            operations.add(
+              AlterColumn(
+                ColumnModification(
+                  table: model.tableName,
+                  column: field.columnName,
+                  defaultValue: defaultValue,
+                ),
+              ),
+            );
+          } else {
+            operations.add(
+              AlterColumn(
+                ColumnModification(
+                  table: model.tableName,
+                  column: field.columnName,
+                  dropDefault: true,
+                ),
+              ),
+            );
+          }
+        }
+
+        // Check for maxLength changes (varchar/char columns)
+        if (field.maxLength != null && dbColumn.maxLength != null && field.maxLength != dbColumn.maxLength) {
+          operations.add(
+            AlterColumn(
+              ColumnModification(
+                table: model.tableName,
+                column: field.columnName,
+                type: field.dbType,
+              ),
+            ),
+          );
+        }
+
+        // Check for precision/scale changes (decimal columns)
+        // Only compare when the DB reports values (SQLite doesn't track precision/scale)
+        if (field.precision != null &&
+            field.scale != null &&
+            dbColumn.precision != null &&
+            dbColumn.scale != null &&
+            (field.precision != dbColumn.precision || field.scale != dbColumn.scale)) {
+          operations.add(
+            AlterColumn(
+              ColumnModification(
+                table: model.tableName,
+                column: field.columnName,
+                type: field.dbType,
+              ),
+            ),
+          );
+        }
+
+        // Check for missing unique constraint
+        if (field.unique && !_hasUniqueConstraint(dbSchema, field.columnName)) {
+          operations.add(
+            CreateIndex(
+              model.tableName,
+              IndexDefinition(
+                name: 'idx_${model.tableName}_${field.columnName}_unique',
+                columns: [field.columnName],
+                unique: true,
+              ),
+            ),
+          );
+        }
+
+        // Check for missing foreign key constraint
+        if (field.foreignKey != null && !_hasForeignKeyConstraint(dbSchema, field.columnName)) {
+          operations.add(
+            AddForeignKey(
+              model.tableName,
+              ForeignKeyDefinition(
+                column: field.columnName,
+                referencedTable: field.foreignKey!.referencedTable,
+                referencedColumn: field.foreignKey!.referencedColumn,
+                onDelete: field.foreignKey!.onDelete,
+              ),
+            ),
+          );
+        }
       }
     }
 
@@ -648,6 +733,52 @@ class SchemaGenerator {
   /// Check if a FieldType is an integer-like type.
   ///
   /// Used to avoid false positives when comparing serial vs integer for PKs.
+  /// Compare default values, normalizing DB-reported values against model values.
+  bool _defaultValuesDiffer(String? modelDefault, String? dbDefault) {
+    if (modelDefault == null && dbDefault == null) return false;
+    if (modelDefault == null || dbDefault == null) return true;
+
+    // Normalize: DB may wrap strings in quotes, append type casts, etc.
+    final normalizedModel = _normalizeDefaultValue(modelDefault);
+    final normalizedDb = _normalizeDefaultValue(dbDefault);
+    return normalizedModel != normalizedDb;
+  }
+
+  /// Normalize a default value for comparison.
+  String _normalizeDefaultValue(String value) {
+    var v = value.trim();
+    // Remove Postgres type casts like ::text, ::integer, ::boolean
+    v = v.replaceAll(RegExp(r'::\w+(\[\])?'), '');
+    if (v.startsWith("'") && v.endsWith("'")) {
+      v = v.substring(1, v.length - 1);
+    }
+    return v.toLowerCase();
+  }
+
+  bool _hasUniqueConstraint(TableSchema dbSchema, String columnName) {
+    // Check constraints
+    for (final constraint in dbSchema.constraints) {
+      if (constraint.type == ConstraintType.unique && constraint.columns.contains(columnName)) {
+        return true;
+      }
+    }
+    for (final index in dbSchema.indexes) {
+      if (index.unique && index.columns.contains(columnName)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool _hasForeignKeyConstraint(TableSchema dbSchema, String columnName) {
+    for (final constraint in dbSchema.constraints) {
+      if (constraint.type == ConstraintType.foreignKey && constraint.columns.contains(columnName)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   bool _isIntegerType(FieldType type) {
     return type == FieldType.integer ||
         type == FieldType.smallInt ||

--- a/packages/jao/test/migrations/schema_generator_test.dart
+++ b/packages/jao/test/migrations/schema_generator_test.dart
@@ -1323,6 +1323,124 @@ void main() {
         });
       });
 
+      test('generates drop default when model removes default value', () async {
+        await pool.withConnection((conn) async {
+          await conn.execute('''
+            CREATE TABLE IF NOT EXISTS drop_default_test (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              status TEXT NOT NULL DEFAULT 'pending'
+            )
+          ''');
+
+          const schema = ModelSchema(
+            className: 'DropDefaultTest',
+            tableName: 'drop_default_test',
+            fields: [
+              ModelFieldSchema(
+                name: 'id',
+                columnName: 'id',
+                dbType: FieldType.serial,
+                primaryKey: true,
+                autoIncrement: true,
+              ),
+              ModelFieldSchema(
+                name: 'status',
+                columnName: 'status',
+                dbType: FieldType.text,
+                // no defaultValue — model removed it
+              ),
+            ],
+          );
+
+          final operations = await generator.generateDiff(conn, [schema]);
+
+          final alterOps = operations.whereType<AlterColumn>().toList();
+          expect(alterOps.isNotEmpty, isTrue, reason: 'Should detect removed default value');
+          expect(alterOps.any((op) => op.modification.dropDefault), isTrue, reason: 'Should generate DROP DEFAULT');
+        });
+      });
+
+      test('does not add foreign key if already exists', () async {
+        await pool.withConnection((conn) async {
+          await conn.execute('''
+            CREATE TABLE IF NOT EXISTS fk_exists_parent (
+              id INTEGER PRIMARY KEY AUTOINCREMENT
+            )
+          ''');
+          await conn.execute('''
+            CREATE TABLE IF NOT EXISTS fk_exists_child (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              parent_id INTEGER NOT NULL REFERENCES fk_exists_parent(id)
+            )
+          ''');
+
+          const schema = ModelSchema(
+            className: 'FkExistsChild',
+            tableName: 'fk_exists_child',
+            fields: [
+              ModelFieldSchema(
+                name: 'id',
+                columnName: 'id',
+                dbType: FieldType.serial,
+                primaryKey: true,
+                autoIncrement: true,
+              ),
+              ModelFieldSchema(
+                name: 'parentId',
+                columnName: 'parent_id',
+                dbType: FieldType.integer,
+                foreignKey: ForeignKeyInfo(
+                  referencedTable: 'fk_exists_parent',
+                  referencedColumn: 'id',
+                ),
+              ),
+            ],
+          );
+
+          final operations = await generator.generateDiff(conn, [schema]);
+
+          final fkOps = operations.whereType<AddForeignKey>().toList();
+          expect(fkOps.isEmpty, isTrue, reason: 'Should not add FK if already present');
+        });
+      });
+
+      test('detects changed default value on existing column', () async {
+        await pool.withConnection((conn) async {
+          await conn.execute('''
+            CREATE TABLE IF NOT EXISTS changed_default_test (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              priority INTEGER NOT NULL DEFAULT 0
+            )
+          ''');
+
+          const schema = ModelSchema(
+            className: 'ChangedDefaultTest',
+            tableName: 'changed_default_test',
+            fields: [
+              ModelFieldSchema(
+                name: 'id',
+                columnName: 'id',
+                dbType: FieldType.serial,
+                primaryKey: true,
+                autoIncrement: true,
+              ),
+              ModelFieldSchema(
+                name: 'priority',
+                columnName: 'priority',
+                dbType: FieldType.integer,
+                defaultValue: '5',
+              ),
+            ],
+          );
+
+          final operations = await generator.generateDiff(conn, [schema]);
+
+          final alterOps = operations.whereType<AlterColumn>().toList();
+          expect(alterOps.isNotEmpty, isTrue, reason: 'Should detect changed default value');
+          expect(alterOps.any((op) => op.modification.defaultValue == '5'), isTrue);
+        });
+      });
+
       test('does not add default value if already matches', () async {
         await pool.withConnection((conn) async {
           await conn.execute('''

--- a/packages/jao/test/migrations/schema_generator_test.dart
+++ b/packages/jao/test/migrations/schema_generator_test.dart
@@ -1164,6 +1164,200 @@ void main() {
           expect(operations.whereType<AlterColumn>().isEmpty, isTrue);
         });
       });
+
+      test('detects missing default value on existing column', () async {
+        await pool.withConnection((conn) async {
+          await conn.execute('''
+            CREATE TABLE IF NOT EXISTS default_test (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              status TEXT NOT NULL
+            )
+          ''');
+
+          const schema = ModelSchema(
+            className: 'DefaultTest',
+            tableName: 'default_test',
+            fields: [
+              ModelFieldSchema(
+                name: 'id',
+                columnName: 'id',
+                dbType: FieldType.serial,
+                primaryKey: true,
+                autoIncrement: true,
+              ),
+              ModelFieldSchema(
+                name: 'status',
+                columnName: 'status',
+                dbType: FieldType.text,
+                defaultValue: "'active'",
+              ),
+            ],
+          );
+
+          final operations = await generator.generateDiff(conn, [schema]);
+
+          final alterOps = operations.whereType<AlterColumn>().toList();
+          expect(alterOps.isNotEmpty, isTrue, reason: 'Should detect missing default value');
+          expect(alterOps.any((op) => op.modification.defaultValue == "'active'"), isTrue);
+        });
+      });
+
+      test('detects missing unique constraint on existing column', () async {
+        await pool.withConnection((conn) async {
+          await conn.execute('''
+            CREATE TABLE IF NOT EXISTS unique_test (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              email TEXT NOT NULL
+            )
+          ''');
+
+          const schema = ModelSchema(
+            className: 'UniqueTest',
+            tableName: 'unique_test',
+            fields: [
+              ModelFieldSchema(
+                name: 'id',
+                columnName: 'id',
+                dbType: FieldType.serial,
+                primaryKey: true,
+                autoIncrement: true,
+              ),
+              ModelFieldSchema(
+                name: 'email',
+                columnName: 'email',
+                dbType: FieldType.text,
+                unique: true,
+              ),
+            ],
+          );
+
+          final operations = await generator.generateDiff(conn, [schema]);
+
+          final indexOps = operations.whereType<CreateIndex>().toList();
+          expect(indexOps.isNotEmpty, isTrue, reason: 'Should detect missing unique constraint');
+          expect(indexOps.any((op) => op.index.unique && op.index.columns.contains('email')), isTrue);
+        });
+      });
+
+      test('does not add unique constraint if already exists', () async {
+        await pool.withConnection((conn) async {
+          await conn.execute('''
+            CREATE TABLE IF NOT EXISTS unique_exists_test (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              email TEXT NOT NULL UNIQUE
+            )
+          ''');
+
+          const schema = ModelSchema(
+            className: 'UniqueExistsTest',
+            tableName: 'unique_exists_test',
+            fields: [
+              ModelFieldSchema(
+                name: 'id',
+                columnName: 'id',
+                dbType: FieldType.serial,
+                primaryKey: true,
+                autoIncrement: true,
+              ),
+              ModelFieldSchema(
+                name: 'email',
+                columnName: 'email',
+                dbType: FieldType.text,
+                unique: true,
+              ),
+            ],
+          );
+
+          final operations = await generator.generateDiff(conn, [schema]);
+
+          final indexOps = operations.whereType<CreateIndex>().toList();
+          expect(indexOps.isEmpty, isTrue, reason: 'Should not add unique constraint if already present');
+        });
+      });
+
+      test('detects missing foreign key constraint on existing column', () async {
+        await pool.withConnection((conn) async {
+          await conn.execute('''
+            CREATE TABLE IF NOT EXISTS fk_parent (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              name TEXT NOT NULL
+            )
+          ''');
+          await conn.execute('''
+            CREATE TABLE IF NOT EXISTS fk_child (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              parent_id INTEGER NOT NULL
+            )
+          ''');
+
+          const schema = ModelSchema(
+            className: 'FkChild',
+            tableName: 'fk_child',
+            fields: [
+              ModelFieldSchema(
+                name: 'id',
+                columnName: 'id',
+                dbType: FieldType.serial,
+                primaryKey: true,
+                autoIncrement: true,
+              ),
+              ModelFieldSchema(
+                name: 'parentId',
+                columnName: 'parent_id',
+                dbType: FieldType.integer,
+                foreignKey: ForeignKeyInfo(
+                  referencedTable: 'fk_parent',
+                  referencedColumn: 'id',
+                  onDelete: OnDeleteAction.cascade,
+                ),
+              ),
+            ],
+          );
+
+          final operations = await generator.generateDiff(conn, [schema]);
+
+          final fkOps = operations.whereType<AddForeignKey>().toList();
+          expect(fkOps.isNotEmpty, isTrue, reason: 'Should detect missing foreign key');
+          expect(fkOps.first.foreignKey.referencedTable, equals('fk_parent'));
+          expect(fkOps.first.foreignKey.onDelete, equals(OnDeleteAction.cascade));
+        });
+      });
+
+      test('does not add default value if already matches', () async {
+        await pool.withConnection((conn) async {
+          await conn.execute('''
+            CREATE TABLE IF NOT EXISTS default_match_test (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              active INTEGER NOT NULL DEFAULT 0
+            )
+          ''');
+
+          const schema = ModelSchema(
+            className: 'DefaultMatchTest',
+            tableName: 'default_match_test',
+            fields: [
+              ModelFieldSchema(
+                name: 'id',
+                columnName: 'id',
+                dbType: FieldType.serial,
+                primaryKey: true,
+                autoIncrement: true,
+              ),
+              ModelFieldSchema(
+                name: 'active',
+                columnName: 'active',
+                dbType: FieldType.integer,
+                defaultValue: '0',
+              ),
+            ],
+          );
+
+          final operations = await generator.generateDiff(conn, [schema]);
+
+          final alterOps = operations.whereType<AlterColumn>().where((op) => op.modification.column == 'active');
+          expect(alterOps.isEmpty, isTrue, reason: 'Should not alter column when default value already matches');
+        });
+      });
     });
 
     group('generateMigrationFile()', () {


### PR DESCRIPTION
`_generateTableDiff` only compared nullability and type for existing columns. Added comparisons for defaultValue, maxLength, precision/scale, unique constraints, and foreign key constraints so `makemigrations` generates the correct alter/add operations for attributes that were previously ignored.
