### PR TITLE
fix: resolve inherited annotation fields via superclass chain

### DIFF
--- a/packages/jao_generator/lib/src/generator.dart
+++ b/packages/jao_generator/lib/src/generator.dart
@@ -1,3 +1,4 @@
+import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
@@ -69,6 +70,21 @@ class JaoGenerator extends GeneratorForAnnotation<Model> {
     return fields;
   }
 
+  /// Get a field value from a DartObject, traversing the superclass chain.
+  /// `DartObject.getField()` only returns directly declared fields,
+  /// so for inherited fields (e.g., `unique` on `EmailField` which inherits from `Field`)
+  /// we need to walk up via the `(super)` synthetic field.
+  DartObject? _getInheritedField(DartObject? obj, String fieldName) {
+    if (obj == null || obj.isNull) return null;
+    final direct = obj.getField(fieldName);
+    if (direct case final direct? when !direct.isNull) return direct;
+    final superObj = obj.getField('(super)');
+    if (superObj case final superObj? when !superObj.isNull) {
+      return _getInheritedField(superObj, fieldName);
+    }
+    return null;
+  }
+
   String? _extractDefaultValue(dynamic dartObject) {
     if (dartObject == null || dartObject.isNull) return null;
 
@@ -99,23 +115,23 @@ class JaoGenerator extends GeneratorForAnnotation<Model> {
 
       final typeName = type.getDisplayString();
       final baseTypeName = typeName.contains('<') ? typeName.substring(0, typeName.indexOf('<')) : typeName;
-      final defaultValue = _extractDefaultValue(value.getField('defaultValue'));
-      final unique = value.getField('unique')?.toBoolValue() ?? false;
+      final defaultValue = _extractDefaultValue(_getInheritedField(value, 'defaultValue'));
+      final unique = _getInheritedField(value, 'unique')?.toBoolValue() ?? false;
 
       switch (baseTypeName) {
         case 'CharField':
-          final maxLength = value.getField('maxLength')?.toIntValue();
+          final maxLength = _getInheritedField(value, 'maxLength')?.toIntValue();
           return _FieldAnnotationInfo('String', 'StringFieldRef', 'varchar', annotation.toSource(),
               defaultValue: defaultValue, unique: unique, maxLength: maxLength);
         case 'TextField':
           return _FieldAnnotationInfo('String', 'StringFieldRef', 'text', annotation.toSource(),
               defaultValue: defaultValue, unique: unique);
         case 'EmailField':
-          final maxLength = value.getField('maxLength')?.toIntValue();
+          final maxLength = _getInheritedField(value, 'maxLength')?.toIntValue();
           return _FieldAnnotationInfo('String', 'StringFieldRef', 'varchar', annotation.toSource(),
               defaultValue: defaultValue, unique: unique, maxLength: maxLength);
         case 'UrlField':
-          final maxLength = value.getField('maxLength')?.toIntValue();
+          final maxLength = _getInheritedField(value, 'maxLength')?.toIntValue();
           return _FieldAnnotationInfo('String', 'StringFieldRef', 'varchar', annotation.toSource(),
               defaultValue: defaultValue, unique: unique, maxLength: maxLength);
         case 'IntegerField':
@@ -152,16 +168,16 @@ class JaoGenerator extends GeneratorForAnnotation<Model> {
           return _FieldAnnotationInfo('double', 'DoubleFieldRef', 'real', annotation.toSource(),
               defaultValue: defaultValue, unique: unique);
         case 'DecimalField':
-          final maxDigits = value.getField('maxDigits')?.toIntValue();
-          final decimalPlaces = value.getField('decimalPlaces')?.toIntValue();
+          final maxDigits = _getInheritedField(value, 'maxDigits')?.toIntValue();
+          final decimalPlaces = _getInheritedField(value, 'decimalPlaces')?.toIntValue();
           return _FieldAnnotationInfo('double', 'DoubleFieldRef', 'decimal', annotation.toSource(),
               defaultValue: defaultValue, unique: unique, precision: maxDigits, scale: decimalPlaces);
         case 'BooleanField':
           return _FieldAnnotationInfo('bool', 'BoolFieldRef', 'boolean', annotation.toSource(),
               defaultValue: defaultValue);
         case 'DateField':
-          final dateAutoNowAdd = value.getField('autoNowAdd')?.toBoolValue() ?? false;
-          final dateAutoNow = value.getField('autoNow')?.toBoolValue() ?? false;
+          final dateAutoNowAdd = _getInheritedField(value, 'autoNowAdd')?.toBoolValue() ?? false;
+          final dateAutoNow = _getInheritedField(value, 'autoNow')?.toBoolValue() ?? false;
           return _FieldAnnotationInfo(
             'DateTime',
             'DateTimeFieldRef',
@@ -172,8 +188,8 @@ class JaoGenerator extends GeneratorForAnnotation<Model> {
             defaultValue: defaultValue,
           );
         case 'DateTimeField':
-          final autoNowAdd = value.getField('autoNowAdd')?.toBoolValue() ?? false;
-          final autoNow = value.getField('autoNow')?.toBoolValue() ?? false;
+          final autoNowAdd = _getInheritedField(value, 'autoNowAdd')?.toBoolValue() ?? false;
+          final autoNow = _getInheritedField(value, 'autoNow')?.toBoolValue() ?? false;
           return _FieldAnnotationInfo(
             'DateTime',
             'DateTimeFieldRef',
@@ -189,7 +205,7 @@ class JaoGenerator extends GeneratorForAnnotation<Model> {
         case 'ForeignKey':
         case 'OneToOneField':
         case 'ManyToManyField':
-          final toField = value.getField('to');
+          final toField = _getInheritedField(value, 'to');
           String? relatedModel;
           DartType? relatedDartType;
           if (toField != null) {
@@ -198,7 +214,7 @@ class JaoGenerator extends GeneratorForAnnotation<Model> {
               relatedModel = relatedDartType.getDisplayString();
             }
           }
-          final toColumn = value.getField('toColumn')?.toStringValue() ?? 'id';
+          final toColumn = _getInheritedField(value, 'toColumn')?.toStringValue() ?? 'id';
           final relatedTable = relatedModel != null ? _toSnakeCase(relatedModel) : null;
           final relationType = switch (typeName) {
             'ForeignKey' => _RelationType.foreignKey,
@@ -207,7 +223,7 @@ class JaoGenerator extends GeneratorForAnnotation<Model> {
             _ => _RelationType.foreignKey,
           };
           final (pkType, pkFieldRef, pkDbType) = _resolvePkType(relatedDartType);
-          final onDeleteField = value.getField('onDelete');
+          final onDeleteField = _getInheritedField(value, 'onDelete');
           String? onDeleteValue;
           if (onDeleteField case final onDeleteField? when !onDeleteField.isNull) {
             final enumIndex = onDeleteField.getField('index')?.toIntValue();
@@ -231,7 +247,7 @@ class JaoGenerator extends GeneratorForAnnotation<Model> {
                 : null,
           );
         case 'UuidField':
-          final autoGenerate = value.getField('autoGenerate')?.toBoolValue() ?? false;
+          final autoGenerate = _getInheritedField(value, 'autoGenerate')?.toBoolValue() ?? false;
           return _FieldAnnotationInfo(
             'String',
             'StringFieldRef',
@@ -259,7 +275,7 @@ class JaoGenerator extends GeneratorForAnnotation<Model> {
           return _FieldAnnotationInfo('Duration', 'DurationFieldRef', 'time', annotation.toSource(),
               defaultValue: defaultValue);
         case 'EnumField':
-          final storeAsInt = value.getField('storeAsInt')?.toBoolValue() ?? false;
+          final storeAsInt = _getInheritedField(value, 'storeAsInt')?.toBoolValue() ?? false;
           return _FieldAnnotationInfo(
             storeAsInt ? 'int' : 'String',
             storeAsInt ? 'IntFieldRef' : 'StringFieldRef',

--- a/packages/jao_generator/test/generator/generator_integration_test.dart
+++ b/packages/jao_generator/test/generator/generator_integration_test.dart
@@ -754,11 +754,9 @@ class Book {
         outputs: {
           'pkg|lib/models.jao.dart': decodedMatches(
             allOf([
-
               contains('foreignKey: ForeignKeyInfo('),
               contains("referencedTable: 'user'"),
               contains("referencedColumn: 'id'"),
-
               contains('nullable: true'),
             ]),
           ),
@@ -931,13 +929,9 @@ class Task {
         outputs: {
           'pkg|lib/task.jao.dart': decodedMatches(
             allOf([
-
               contains("final status = const StringFieldRef('status')"),
-
               contains("TaskStatus.values.byName(row['status'] as String)"),
-
               contains("'status': model.status.name"),
-
               contains("dbType: FieldType.varchar"),
             ]),
           ),
@@ -967,13 +961,9 @@ class Issue {
         outputs: {
           'pkg|lib/priority.jao.dart': decodedMatches(
             allOf([
-
               contains("final priority = const IntFieldRef('priority')"),
-
               contains("Priority.values[row['priority'] as int]"),
-
               contains("'priority': model.priority.index"),
-
               contains("dbType: FieldType.integer"),
             ]),
           ),
@@ -1002,12 +992,9 @@ class Order {
         outputs: {
           'pkg|lib/order.jao.dart': decodedMatches(
             allOf([
-
               contains("row['shipping_method'] != null"),
               contains("ShippingMethod.values.byName(row['shipping_method'] as String)"),
-
               contains("model.shippingMethod?.name"),
-
               contains("nullable: true"),
             ]),
           ),
@@ -1036,12 +1023,9 @@ class Ticket {
         outputs: {
           'pkg|lib/ticket.jao.dart': decodedMatches(
             allOf([
-
               contains("row['severity'] != null"),
               contains("Severity.values[row['severity'] as int]"),
-
               contains("model.severity?.index"),
-
               contains("nullable: true"),
             ]),
           ),

--- a/packages/jao_generator/test/generator/generator_integration_test.dart
+++ b/packages/jao_generator/test/generator/generator_integration_test.dart
@@ -754,11 +754,11 @@ class Book {
         outputs: {
           'pkg|lib/models.jao.dart': decodedMatches(
             allOf([
-              // Verify schema includes ForeignKeyInfo for FK fields
+
               contains('foreignKey: ForeignKeyInfo('),
               contains("referencedTable: 'user'"),
               contains("referencedColumn: 'id'"),
-              // Verify nullable is true for nullable FK
+
               contains('nullable: true'),
             ]),
           ),
@@ -844,6 +844,34 @@ class FileData {
       );
     });
 
+    test('Generator emits unique and maxLength for EmailField', () async {
+      await testBuilder(
+        builder,
+        {
+          'jao|lib/jao.dart': _jaoStub,
+          'pkg|lib/user.dart': '''
+import 'package:jao/jao.dart';
+
+@Model()
+class User {
+  @AutoField()
+  late int id;
+  @EmailField(unique: true)
+  late String email;
+}
+''',
+        },
+        outputs: {
+          'pkg|lib/user.jao.dart': decodedMatches(
+            allOf([
+              contains('unique: true'),
+              contains('maxLength: 254'),
+            ]),
+          ),
+        },
+      );
+    });
+
     test('Generator handles fields with defaultValue', () async {
       await testBuilder(
         builder,
@@ -903,13 +931,13 @@ class Task {
         outputs: {
           'pkg|lib/task.jao.dart': decodedMatches(
             allOf([
-              // Field ref should be StringFieldRef for string-based enum
+
               contains("final status = const StringFieldRef('status')"),
-              // fromRow should use values.byName
+
               contains("TaskStatus.values.byName(row['status'] as String)"),
-              // toRow should use .name
+
               contains("'status': model.status.name"),
-              // Schema should use varchar
+
               contains("dbType: FieldType.varchar"),
             ]),
           ),
@@ -939,13 +967,13 @@ class Issue {
         outputs: {
           'pkg|lib/priority.jao.dart': decodedMatches(
             allOf([
-              // Field ref should be IntFieldRef for int-based enum
+
               contains("final priority = const IntFieldRef('priority')"),
-              // fromRow should use values[index]
+
               contains("Priority.values[row['priority'] as int]"),
-              // toRow should use .index
+
               contains("'priority': model.priority.index"),
-              // Schema should use integer
+
               contains("dbType: FieldType.integer"),
             ]),
           ),
@@ -974,12 +1002,12 @@ class Order {
         outputs: {
           'pkg|lib/order.jao.dart': decodedMatches(
             allOf([
-              // fromRow should handle null - check key parts
+
               contains("row['shipping_method'] != null"),
               contains("ShippingMethod.values.byName(row['shipping_method'] as String)"),
-              // toRow should use ?.name
+
               contains("model.shippingMethod?.name"),
-              // Schema should mark nullable
+
               contains("nullable: true"),
             ]),
           ),
@@ -1008,12 +1036,12 @@ class Ticket {
         outputs: {
           'pkg|lib/ticket.jao.dart': decodedMatches(
             allOf([
-              // fromRow should handle null - check key parts
+
               contains("row['severity'] != null"),
               contains("Severity.values[row['severity'] as int]"),
-              // toRow should use ?.index
+
               contains("model.severity?.index"),
-              // Schema should mark nullable
+
               contains("nullable: true"),
             ]),
           ),
@@ -1041,17 +1069,17 @@ class BigAutoField {
 
 class CharField {
   final int maxLength;
+  final bool unique;
   final Object? defaultValue;
-  const CharField({this.maxLength = 255, this.defaultValue});
+  const CharField({this.maxLength = 255, this.unique = false, this.defaultValue});
 }
 
 class TextField {
   const TextField();
 }
 
-class EmailField {
-  final int maxLength;
-  const EmailField({this.maxLength = 254});
+class EmailField extends CharField {
+  const EmailField({super.maxLength = 254, super.unique});
 }
 
 class UrlField {


### PR DESCRIPTION
`DartObject.getField()` only returns directly declared fields, so inherited attributes like `unique`, `maxLength`, and `defaultValue` were silently dropped for subclass annotations (e.g., `EmailField extends CharField extends Field`).

Added `_getInheritedField()` to walk the (`super`) chain and applied it to all annotation field reads.
