### PR TITLE
refactor: change ModelFieldSchema.defaultValue from String? to Object?

### DIFF
--- a/packages/jao/lib/src/migrations/generator.dart
+++ b/packages/jao/lib/src/migrations/generator.dart
@@ -37,7 +37,7 @@ class ModelFieldSchema {
   final bool index;
   final bool primaryKey;
   final bool autoIncrement;
-  final String? defaultValue;
+  final Object? defaultValue;
   final int? maxLength;
   final int? precision;
   final int? scale;
@@ -151,12 +151,22 @@ class SchemaGenerator {
           field.columnName,
           length: field.maxLength ?? 255,
           nullable: field.nullable,
-          defaultValue: field.defaultValue,
+          defaultValue: switch (field.defaultValue) {
+            final String v => v,
+            _ => null,
+          },
         );
         if (field.unique) builder.unique(field.columnName);
 
       case FieldType.text:
-        builder.text(field.columnName, nullable: field.nullable, defaultValue: field.defaultValue);
+        builder.text(
+          field.columnName,
+          nullable: field.nullable,
+          defaultValue: switch (field.defaultValue) {
+            final String v => v,
+            _ => null,
+          },
+        );
 
       case FieldType.integer:
       case FieldType.smallInt:
@@ -174,7 +184,7 @@ class SchemaGenerator {
             field.columnName,
             nullable: field.nullable,
             defaultValue: switch (field.defaultValue) {
-              final value? => int.tryParse(value),
+              final int v => v,
               _ => null,
             },
           );
@@ -185,7 +195,7 @@ class SchemaGenerator {
           field.columnName,
           nullable: field.nullable,
           defaultValue: switch (field.defaultValue) {
-            final value? => double.tryParse(value),
+            final double v => v,
             _ => null,
           },
         );
@@ -194,7 +204,7 @@ class SchemaGenerator {
           field.columnName,
           nullable: field.nullable,
           defaultValue: switch (field.defaultValue) {
-            final value? => double.tryParse(value),
+            final double v => v,
             _ => null,
           },
         );
@@ -205,7 +215,10 @@ class SchemaGenerator {
           precision: field.precision ?? 10,
           scale: field.scale ?? 2,
           nullable: field.nullable,
-          defaultValue: field.defaultValue,
+          defaultValue: switch (field.defaultValue) {
+            final String v => v,
+            _ => null,
+          },
         );
 
       case FieldType.boolean:
@@ -213,13 +226,20 @@ class SchemaGenerator {
           field.columnName,
           nullable: field.nullable,
           defaultValue: switch (field.defaultValue) {
-            final value? => value.toLowerCase() == 'true',
+            final bool v => v,
             _ => null,
           },
         );
 
       case FieldType.date:
-        builder.date(field.columnName, nullable: field.nullable, defaultValue: field.defaultValue);
+        builder.date(
+          field.columnName,
+          nullable: field.nullable,
+          defaultValue: switch (field.defaultValue) {
+            final String v => v,
+            _ => null,
+          },
+        );
 
       case FieldType.timestamp:
       case FieldType.timestampTz:
@@ -230,11 +250,25 @@ class SchemaGenerator {
         );
 
       case FieldType.uuid:
-        builder.uuidColumn(field.columnName, nullable: field.nullable, defaultValue: field.defaultValue);
+        builder.uuidColumn(
+          field.columnName,
+          nullable: field.nullable,
+          defaultValue: switch (field.defaultValue) {
+            final String v => v,
+            _ => null,
+          },
+        );
 
       case FieldType.json:
       case FieldType.jsonb:
-        builder.jsonb(field.columnName, nullable: field.nullable, defaultValue: field.defaultValue);
+        builder.jsonb(
+          field.columnName,
+          nullable: field.nullable,
+          defaultValue: switch (field.defaultValue) {
+            final String v => v,
+            _ => null,
+          },
+        );
 
       case FieldType.bytea:
       case FieldType.blob:
@@ -289,7 +323,7 @@ class SchemaGenerator {
               name: field.columnName,
               type: field.dbType,
               nullable: field.nullable,
-              defaultValue: field.defaultValue,
+              defaultValue: field.defaultValue?.toString(),
               length: field.maxLength,
               precision: field.precision,
               scale: field.scale,
@@ -366,7 +400,7 @@ class SchemaGenerator {
                 ColumnModification(
                   table: model.tableName,
                   column: field.columnName,
-                  defaultValue: defaultValue,
+                  defaultValue: defaultValue.toString(),
                 ),
               ),
             );
@@ -734,12 +768,11 @@ class SchemaGenerator {
   ///
   /// Used to avoid false positives when comparing serial vs integer for PKs.
   /// Compare default values, normalizing DB-reported values against model values.
-  bool _defaultValuesDiffer(String? modelDefault, String? dbDefault) {
+  bool _defaultValuesDiffer(Object? modelDefault, String? dbDefault) {
     if (modelDefault == null && dbDefault == null) return false;
     if (modelDefault == null || dbDefault == null) return true;
 
-    // Normalize: DB may wrap strings in quotes, append type casts, etc.
-    final normalizedModel = _normalizeDefaultValue(modelDefault);
+    final normalizedModel = _normalizeDefaultValue(modelDefault.toString());
     final normalizedDb = _normalizeDefaultValue(dbDefault);
     return normalizedModel != normalizedDb;
   }

--- a/packages/jao/test/migrations/schema_generator_test.dart
+++ b/packages/jao/test/migrations/schema_generator_test.dart
@@ -108,10 +108,10 @@ void main() {
         name: 'isActive',
         columnName: 'is_active',
         dbType: FieldType.boolean,
-        defaultValue: 'true',
+        defaultValue: true,
       );
 
-      expect(field.defaultValue, equals('true'));
+      expect(field.defaultValue, equals(true));
     });
 
     test('stores varchar maxLength', () {
@@ -247,7 +247,7 @@ void main() {
               name: 'isActive',
               columnName: 'is_active',
               dbType: FieldType.boolean,
-              defaultValue: 'true',
+              defaultValue: true,
             ),
             ModelFieldSchema(name: 'birthDate', columnName: 'birth_date', dbType: FieldType.date),
             ModelFieldSchema(
@@ -1189,7 +1189,7 @@ void main() {
                 name: 'status',
                 columnName: 'status',
                 dbType: FieldType.text,
-                defaultValue: "'active'",
+                defaultValue: 'active',
               ),
             ],
           );
@@ -1198,7 +1198,7 @@ void main() {
 
           final alterOps = operations.whereType<AlterColumn>().toList();
           expect(alterOps.isNotEmpty, isTrue, reason: 'Should detect missing default value');
-          expect(alterOps.any((op) => op.modification.defaultValue == "'active'"), isTrue);
+          expect(alterOps.any((op) => op.modification.defaultValue == 'active'), isTrue);
         });
       });
 
@@ -1428,7 +1428,7 @@ void main() {
                 name: 'priority',
                 columnName: 'priority',
                 dbType: FieldType.integer,
-                defaultValue: '5',
+                defaultValue: 5,
               ),
             ],
           );
@@ -1465,7 +1465,7 @@ void main() {
                 name: 'active',
                 columnName: 'active',
                 dbType: FieldType.integer,
-                defaultValue: '0',
+                defaultValue: 0,
               ),
             ],
           );
@@ -1938,7 +1938,7 @@ void main() {
             columnName: 'value',
             dbType: FieldType.doublePrecision,
             nullable: true,
-            defaultValue: '3.14159',
+            defaultValue: 3.14159,
           ),
         ],
       );

--- a/packages/jao_generator/lib/src/generator.dart
+++ b/packages/jao_generator/lib/src/generator.dart
@@ -85,22 +85,13 @@ class JaoGenerator extends GeneratorForAnnotation<Model> {
     return null;
   }
 
-  String? _extractDefaultValue(dynamic dartObject) {
+  Object? _extractDefaultValue(dynamic dartObject) {
     if (dartObject == null || dartObject.isNull) return null;
 
-    if (dartObject.toIntValue() case final intVal?) {
-      return intVal.toString();
-    }
-    if (dartObject.toDoubleValue() case final doubleVal?) {
-      return doubleVal.toString();
-    }
-    if (dartObject.toBoolValue() case final boolVal?) {
-      return boolVal.toString();
-    }
-    if (dartObject.toStringValue() case final stringVal?) {
-      final escaped = stringVal.replaceAll("'", "\\'");
-      return "'$escaped'";
-    }
+    if (dartObject.toIntValue() case final intVal?) return intVal;
+    if (dartObject.toDoubleValue() case final doubleVal?) return doubleVal;
+    if (dartObject.toBoolValue() case final boolVal?) return boolVal;
+    if (dartObject.toStringValue() case final stringVal?) return stringVal;
 
     return null;
   }
@@ -444,7 +435,11 @@ class JaoGenerator extends GeneratorForAnnotation<Model> {
       buffer.writeln('        defaultValues: {');
       for (final f in fieldsWithDefaults) {
         final columnName = _toSnakeCase(f.name);
-        buffer.writeln("          '$columnName': ${f.defaultValue},");
+        final emittedValue = switch (f.defaultValue) {
+          final String v => "'$v'",
+          final v => '$v',
+        };
+        buffer.writeln("          '$columnName': $emittedValue,");
       }
       buffer.writeln('        },');
     }
@@ -508,7 +503,11 @@ class JaoGenerator extends GeneratorForAnnotation<Model> {
         buffer.writeln('        scale: $scale,');
       }
       if (field.defaultValue case final defaultValue?) {
-        buffer.writeln("        defaultValue: $defaultValue,");
+        final emittedValue = switch (defaultValue) {
+          final String v => "'$v'",
+          _ => '$defaultValue',
+        };
+        buffer.writeln("        defaultValue: $emittedValue,");
       }
       if (field.relation case final relation?) {
         final onDelete = field.onDelete ?? 'cascade';
@@ -697,7 +696,7 @@ class _FieldInfo {
   final bool autoNowAdd;
   final bool autoNow;
   final bool autoGenerateUuid;
-  final String? defaultValue;
+  final Object? defaultValue;
   final _RelationInfo? relation;
   final bool isEnum;
   final bool storeEnumAsInt;
@@ -757,7 +756,7 @@ class _FieldAnnotationInfo {
   final bool autoNowAdd;
   final bool autoNow;
   final bool autoGenerateUuid;
-  final String? defaultValue;
+  final Object? defaultValue;
   final _RelationInfo? relation;
   final bool isEnum;
   final bool storeEnumAsInt;

--- a/packages/jao_generator/test/generator/generator_test.dart
+++ b/packages/jao_generator/test/generator/generator_test.dart
@@ -424,7 +424,7 @@ class User {
 }
 ''');
 
-      expect(result, contains('defaultValue: false'));
+      expect(result, contains("defaultValue: false"));
     });
 
     test('emits defaultValue in ModelFieldSchema for CharField', () async {


### PR DESCRIPTION
Eliminates round-trip string parsing for default values. Values now stay typed (`bool`, `int, `double`, `String`) through the pipeline, with `toString()` applied only at the SQL boundary.

Updated `_addFieldToBuilder` to use pattern matching instead of string parsing, and `_extractDefaultValue` to return typed values directly.