### PR TITLE
feat: store previous state on ColumnModification for reversible AlterColumn migrations

### DIFF
--- a/packages/jao/lib/src/migrations/generator.dart
+++ b/packages/jao/lib/src/migrations/generator.dart
@@ -386,6 +386,7 @@ class SchemaGenerator {
                   table: model.tableName,
                   column: field.columnName,
                   type: field.dbType,
+                  previousType: normalizedDbType,
                 ),
               ),
             );
@@ -401,6 +402,7 @@ class SchemaGenerator {
                   table: model.tableName,
                   column: field.columnName,
                   defaultValue: defaultValue.toString(),
+                  previousDefault: dbColumn.defaultValue,
                 ),
               ),
             );
@@ -411,6 +413,7 @@ class SchemaGenerator {
                   table: model.tableName,
                   column: field.columnName,
                   dropDefault: true,
+                  previousDefault: dbColumn.defaultValue,
                 ),
               ),
             );
@@ -676,12 +679,23 @@ class SchemaGenerator {
         return "${indent}builder.renameColumn('${op.table}', '${op.newName}', '${op.oldName}');";
       case AlterColumn():
         final mod = op.modification;
+        if (mod.rename != null) {
+          return "${indent}builder.renameColumn('${mod.table}', '${mod.rename}', '${mod.column}');";
+        }
         if (mod.nullable case final nullable?) {
-          final reverseNullable = !nullable;
-          final reverseMethod = reverseNullable ? 'col.nullable()' : 'col.notNullable()';
+          final reverseMethod = nullable ? 'col.notNullable()' : 'col.nullable()';
           return "${indent}builder.alterColumn('${mod.table}', '${mod.column}', (col) {\n$indent  $reverseMethod;\n$indent});";
         }
-        return '$indent// TODO: Manual reversal needed for AlterColumn';
+        if (mod.previousType case final previousType? when mod.type != null) {
+          return "${indent}builder.alterColumn('${mod.table}', '${mod.column}', (col) {\n$indent  col.type(FieldType.${previousType.name});\n$indent});";
+        }
+        if (mod.defaultValue != null && mod.previousDefault != null) {
+          return "${indent}builder.alterColumn('${mod.table}', '${mod.column}', (col) {\n$indent  col.defaultValue('${mod.previousDefault}');\n$indent});";
+        }
+        if (mod.dropDefault && mod.previousDefault != null) {
+          return "${indent}builder.alterColumn('${mod.table}', '${mod.column}', (col) {\n$indent  col.defaultValue('${mod.previousDefault}');\n$indent});";
+        }
+        return '$indent// Cannot auto-reverse AlterColumn: original state unknown';
       case CreateIndex():
         return "${indent}builder.dropIndex('${op.index.name}');";
       case DropIndex():

--- a/packages/jao/lib/src/migrations/schema.dart
+++ b/packages/jao/lib/src/migrations/schema.dart
@@ -512,6 +512,8 @@ class ColumnModification {
   final String? defaultValue;
   final String? rename;
   final bool dropDefault;
+  final FieldType? previousType;
+  final String? previousDefault;
 
   const ColumnModification({
     required this.table,
@@ -521,5 +523,7 @@ class ColumnModification {
     this.defaultValue,
     this.rename,
     this.dropDefault = false,
+    this.previousType,
+    this.previousDefault,
   });
 }

--- a/packages/jao/test/migrations/schema_generator_test.dart
+++ b/packages/jao/test/migrations/schema_generator_test.dart
@@ -1559,6 +1559,81 @@ void main() {
         expect(content, contains("builder.dropIndex('idx_users_email')"));
       });
 
+      test('generates reverse for AlterColumn nullability change', () {
+        const operations = [
+          AlterColumn(ColumnModification(table: 'users', column: 'name', nullable: true)),
+        ];
+
+        final content = generator.generateMigrationFile('MakeNameNullable', operations);
+
+        expect(content, contains('col.notNullable()'));
+      });
+
+      test('generates reverse for AlterColumn type change with previousType', () {
+        const operations = [
+          AlterColumn(ColumnModification(
+            table: 'users',
+            column: 'age',
+            type: FieldType.bigInt,
+            previousType: FieldType.integer,
+          )),
+        ];
+
+        final content = generator.generateMigrationFile('ChangeAgeType', operations);
+
+        expect(content, contains('col.type(FieldType.integer)'));
+      });
+
+      test('generates reverse for AlterColumn default value change with previousDefault', () {
+        const operations = [
+          AlterColumn(ColumnModification(
+            table: 'users',
+            column: 'status',
+            defaultValue: 'active',
+            previousDefault: 'pending',
+          )),
+        ];
+
+        final content = generator.generateMigrationFile('ChangeStatusDefault', operations);
+
+        expect(content, contains("col.defaultValue('pending')"));
+      });
+
+      test('generates reverse for AlterColumn drop default with previousDefault', () {
+        const operations = [
+          AlterColumn(ColumnModification(
+            table: 'users',
+            column: 'status',
+            dropDefault: true,
+            previousDefault: 'active',
+          )),
+        ];
+
+        final content = generator.generateMigrationFile('DropStatusDefault', operations);
+
+        expect(content, contains("col.defaultValue('active')"));
+      });
+
+      test('generates reverse for AlterColumn rename', () {
+        const operations = [
+          AlterColumn(ColumnModification(table: 'users', column: 'name', rename: 'full_name')),
+        ];
+
+        final content = generator.generateMigrationFile('RenameName', operations);
+
+        expect(content, contains("builder.renameColumn('users', 'full_name', 'name')"));
+      });
+
+      test('generates comment when AlterColumn has no previous state', () {
+        const operations = [
+          AlterColumn(ColumnModification(table: 'users', column: 'age', type: FieldType.bigInt)),
+        ];
+
+        final content = generator.generateMigrationFile('ChangeAge', operations);
+
+        expect(content, contains('Cannot auto-reverse AlterColumn'));
+      });
+
       test('converts PascalCase to snake_case for migration name', () {
         final content = generator.generateMigrationFile('CreateUserRolesTable', []);
 


### PR DESCRIPTION
Added `previousType` and `previousDefault` to `ColumnModification` so the reverse code generator can produce correct `down()` methods for type changes, default value changes, and default drops. The diff engine now captures the DB column's current state when creating `AlterColumn` operations.